### PR TITLE
fix: mount PVC to /config for openclaw instances instead of /home/use…

### DIFF
--- a/backend/internal/services/instance_runtime.go
+++ b/backend/internal/services/instance_runtime.go
@@ -58,6 +58,7 @@ func buildRuntimeConfig(instanceType, osType, osVersion string, registry, tag *s
 			"SUBFOLDER":   "/",
 		}
 	case "openclaw":
+		config.MountPath = "/config"
 		if (registry == nil || strings.TrimSpace(*registry) == "") && (tag == nil || strings.TrimSpace(*tag) == "") {
 			config.Image = defaultSystemImageSettings["openclaw"]
 		} else {
@@ -84,7 +85,7 @@ func defaultPortForInstanceType(instanceType string) int32 {
 
 func defaultMountPathForInstanceType(instanceType string) string {
 	switch instanceType {
-	case "ubuntu", "webtop":
+	case "ubuntu", "webtop", "openclaw":
 		return "/config"
 	default:
 		return "/home/user/data"

--- a/backend/internal/services/k8s/pvc_service.go
+++ b/backend/internal/services/k8s/pvc_service.go
@@ -108,9 +108,9 @@ func (s *PVCService) CreatePVC(ctx context.Context, userID, instanceID int, stor
 		return nil, fmt.Errorf("failed to create PVC %s: %w", pvcName, err)
 	}
 
-	// Wait for PVC to be bound, if not bound within timeout, create PV manually
+	// Wait for PVC to be bound by the dynamic provisioner
 	fmt.Printf("PVC %s created, scheduling async binding monitor...\n", pvcName)
-	go s.monitorPVCBinding(context.Background(), namespace, pvcName, userID, instanceID, storageSizeGB, storageClass, 15*time.Second)
+	go s.monitorPVCBinding(context.Background(), namespace, pvcName, userID, instanceID, storageSizeGB, storageClass, 60*time.Second)
 
 	return createdPVC, nil
 }
@@ -142,9 +142,12 @@ func (s *PVCService) waitForPVCBinding(ctx context.Context, namespace, pvcName s
 	for {
 		select {
 		case <-timeoutChan:
-			// Timeout, try to create PV manually
-			fmt.Printf("PVC %s binding timeout, creating PV manually\n", pvcName)
-			return s.createPVForPVC(ctx, namespace, pvcName, userID, instanceID, storageSizeGB, storageClass)
+			fmt.Printf("PVC %s binding timeout after waiting, returning current PVC (dynamic provisioner should bind it eventually)\n", pvcName)
+			pvc, err = s.client.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get PVC %s after timeout: %w", pvcName, err)
+			}
+			return pvc, nil
 		case <-ticker.C:
 			pvc, err := s.client.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
…r/data

OpenClaw images use linuxserver.io base with home dir at /config (user abc, uid 1000). All app state (.openclaw/) writes to /config, but PVC was mounted at /home/user/data — resulting in no persistence across pod restarts.

Also increase PVC binding timeout from 15s to 60s and remove the hostPath fallback that created unreliable node-local PVs under /tmp.