### PR TITLE
docs: add ARM64 (aarch64) deployment guide

### DIFF
--- a/docs/arm64-deployment.md
+++ b/docs/arm64-deployment.md
@@ -1,0 +1,112 @@
+# ARM64 部署说明
+
+## ARM64 平台支持
+
+本项目支持在 ARM64 (aarch64) 架构上部署，如树莓派、ARM开发板等设备。
+
+## 预构建 ARM64 镜像
+
+以下镜像已构建并发布到 GitHub Container Registry：
+
+| 镜像 | 地址 | 说明 |
+|------|------|------|
+| ClawManager 主应用 | `ghcr.io/xty00/clawmanager:latest` | ARM64版本 |
+| Skill Scanner | `ghcr.io/xty00/skill-scanner:latest` | ARM64版本（官方原仓库无ARM64支持） |
+
+### 使用预构建镜像
+
+```bash
+# 拉取ARM64镜像
+docker pull ghcr.io/xty00/clawmanager:latest --platform linux/arm64
+docker pull ghcr.io/xty00/skill-scanner:latest --platform linux/arm64
+```
+
+## 从源码构建 ARM64 镜像
+
+### 后端静态编译
+
+```bash
+cd backend
+CGO_ENABLED=0 go build -ldflags="-s -w -extldflags=-static" -o bin/clawreef-server ./cmd/server
+```
+
+### Docker 多平台构建
+
+```bash
+# 构建并推送多平台镜像
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/your-name/clawmanager:latest --push .
+```
+
+### skill-scanner ARM64 构建
+
+skill-scanner 原仓库 (`ghcr.io/yuan-lab-llm/skill-scanner`) 仅支持 amd64 平台。
+
+ARM64 用户需要从源码构建：
+
+```bash
+# 克隆仓库
+git clone https://github.com/Yuan-lab-LLM/skill-scanner.git
+cd skill-scanner
+
+# 使用代理构建（国内网络需要）
+export http_proxy="http://your-proxy:port"
+export https_proxy="http://your-proxy:port"
+
+# 构建并推送ARM64镜像
+docker buildx build --platform linux/arm64 \
+  -t ghcr.io/your-name/skill-scanner:latest \
+  --push .
+```
+
+## Kubernetes ARM64 部署
+
+### 修改镜像地址
+
+在 `clawmanager.yaml` 中将镜像地址替换为 ARM64 版本：
+
+```yaml
+# 主应用
+image: ghcr.io/xty00/clawmanager:latest
+
+# skill-scanner（如果需要）
+image: ghcr.io/xty00/skill-scanner:latest
+```
+
+### 数据库初始化
+
+首次部署需要手动创建数据库用户：
+
+```bash
+kubectl exec -it -n clawmanager-system mysql-xxx -- mysql -u root
+
+# 在MySQL中执行
+CREATE USER IF NOT EXISTS 'clawmanager'@'%' IDENTIFIED BY 'your-password';
+GRANT ALL PRIVILEGES ON *.* TO 'clawmanager'@'%' WITH GRANT OPTION;
+CREATE DATABASE IF NOT EXISTS clawmanager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+FLUSH PRIVILEGES;
+```
+
+## 已知问题
+
+### skill-scanner 官方镜像无 ARM64 支持
+
+- **问题**: `ghcr.io/yuan-lab-llm/skill-scanner:latest` 仅提供 amd64 平台
+- **解决方案**: 使用第三方构建的 ARM64 镜像 `ghcr.io/xty00/skill-scanner:latest`
+- **备选方案**: 从源码自行构建（见上文）
+
+### ARM64 设备性能注意
+
+- 建议设备内存 >= 4GB
+- 建议使用 SSD 存储（项目数据目录 `/mnt/Storage1`）
+- 建议配置 swap 以避免内存不足
+
+## 测试环境
+
+以下环境已验证可正常运行：
+
+- **开发板**: S922X-Oes-Plus (Amlogic S922X)
+- **系统**: Armbian OS 26.05.0 trixie
+- **内核**: 6.12.80-ophub
+- **内存**: 3.6GB RAM
+- **存储**: 110GB SSD
+- **集群**: k3s v1.34.6

--- a/docs/arm64-deployment_en.md
+++ b/docs/arm64-deployment_en.md
@@ -1,0 +1,112 @@
+# ARM64 Deployment Guide
+
+## ARM64 Platform Support
+
+This project supports deployment on ARM64 (aarch64) architecture devices such as Raspberry Pi and ARM development boards.
+
+## Pre-built ARM64 Images
+
+The following images have been built and published to GitHub Container Registry:
+
+| Image | Address | Description |
+|-------|---------|-------------|
+| ClawManager Main App | `ghcr.io/xty00/clawmanager:latest` | ARM64 version |
+| Skill Scanner | `ghcr.io/xty00/skill-scanner:latest` | ARM64 version (official repo has no ARM64 support) |
+
+### Using Pre-built Images
+
+```bash
+# Pull ARM64 images
+docker pull ghcr.io/xty00/clawmanager:latest --platform linux/arm64
+docker pull ghcr.io/xty00/skill-scanner:latest --platform linux/arm64
+```
+
+## Building ARM64 Images from Source
+
+### Backend Static Compilation
+
+```bash
+cd backend
+CGO_ENABLED=0 go build -ldflags="-s -w -extldflags=-static" -o bin/clawreef-server ./cmd/server
+```
+
+### Docker Multi-platform Build
+
+```bash
+# Build and push multi-platform images
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/your-name/clawmanager:latest --push .
+```
+
+### skill-scanner ARM64 Build
+
+The skill-scanner official repo (`ghcr.io/yuan-lab-llm/skill-scanner`) only supports amd64 platform.
+
+ARM64 users need to build from source:
+
+```bash
+# Clone the repo
+git clone https://github.com/Yuan-lab-LLM/skill-scanner.git
+cd skill-scanner
+
+# Use proxy if needed (for China networks)
+export http_proxy="http://your-proxy:port"
+export https_proxy="http://your-proxy:port"
+
+# Build and push ARM64 image
+docker buildx build --platform linux/arm64 \
+  -t ghcr.io/your-name/skill-scanner:latest \
+  --push .
+```
+
+## Kubernetes ARM64 Deployment
+
+### Modify Image Addresses
+
+In `clawmanager.yaml`, replace image addresses with ARM64 versions:
+
+```yaml
+# Main app
+image: ghcr.io/xty00/clawmanager:latest
+
+# skill-scanner (if needed)
+image: ghcr.io/xty00/skill-scanner:latest
+```
+
+### Database Initialization
+
+Manual database user creation is required for first deployment:
+
+```bash
+kubectl exec -it -n clawmanager-system mysql-xxx -- mysql -u root
+
+# Execute in MySQL
+CREATE USER IF NOT EXISTS 'clawmanager'@'%' IDENTIFIED BY 'your-password';
+GRANT ALL PRIVILEGES ON *.* TO 'clawmanager'@'%' WITH GRANT OPTION;
+CREATE DATABASE IF NOT EXISTS clawmanager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+FLUSH PRIVILEGES;
+```
+
+## Known Issues
+
+### skill-scanner Official Image Has No ARM64 Support
+
+- **Problem**: `ghcr.io/yuan-lab-llm/skill-scanner:latest` only provides amd64 platform
+- **Solution**: Use third-party ARM64 image `ghcr.io/xty00/skill-scanner:latest`
+- **Alternative**: Build from source (see above)
+
+### ARM64 Device Performance Notes
+
+- Recommended device memory >= 4GB
+- Recommended SSD storage (project data directory `/mnt/Storage1`)
+- Recommended swap configuration to avoid OOM
+
+## Tested Environment
+
+The following environment has been verified to work:
+
+- **Board**: S922X-Oes-Plus (Amlogic S922X)
+- **OS**: Armbian OS 26.05.0 trixie
+- **Kernel**: 6.12.80-ophub
+- **Memory**: 3.6GB RAM
+- **Storage**: 110GB SSD
+- **Cluster**: k3s v1.34.6


### PR DESCRIPTION
## Summary

Add ARM64 (aarch64) deployment documentation for ClawManager.

### Changes

- `docs/arm64-deployment.md` - Chinese deployment guide
- `docs/arm64-deployment_en.md` - English deployment guide

### Motivation

Many users want to deploy ClawManager on ARM64 devices such as:
- Raspberry Pi (3/4/5)
- ARM development boards (S922X, RK3588, etc.)

The official Docker images only support amd64 platform, causing deployment failures on ARM64.

### Content

1. Pre-built ARM64 images (`ghcr.io/xty00/clawmanager:latest`, `ghcr.io/xty00/skill-scanner:latest`)
2. Backend static compilation for ARM64
3. Docker multi-platform build instructions
4. skill-scanner ARM64 build from source (since official has no ARM64 support)
5. Kubernetes ARM64 deployment guide
6. Known issues and workarounds

### Testing

Tested on:
- Board: S922X-Oes-Plus (Amlogic S922X)
- OS: Armbian OS 26.05.0 trixie
- Memory: 3.6GB RAM
- Storage: 110GB SSD
- Cluster: k3s v1.34.6

### Checklist

- [x] Documentation added
- [x] Follows existing docs structure
- [x] No sensitive information included