### PR TITLE
feat: support multiple runtime images per instance type

### DIFF
--- a/backend/internal/handlers/system_settings_handler.go
+++ b/backend/internal/handlers/system_settings_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"clawreef/internal/models"
@@ -16,6 +17,7 @@ type SystemSettingsHandler struct {
 }
 
 type UpsertSystemImageSettingRequest struct {
+	ID           int    `json:"id,omitempty"`
 	InstanceType string `json:"instance_type" binding:"required"`
 	DisplayName  string `json:"display_name"`
 	Image        string `json:"image" binding:"required"`
@@ -45,24 +47,33 @@ func (h *SystemSettingsHandler) UpsertSystemImageSetting(c *gin.Context) {
 	}
 
 	setting := &models.SystemImageSetting{
+		ID:           req.ID,
 		InstanceType: strings.TrimSpace(req.InstanceType),
 		DisplayName:  strings.TrimSpace(req.DisplayName),
 		Image:        strings.TrimSpace(req.Image),
 	}
 
-	if err := h.systemImageSettingService.Save(setting); err != nil {
+	saved, err := h.systemImageSettingService.Save(setting)
+	if err != nil {
 		utils.HandleError(c, err)
 		return
 	}
 
-	utils.Success(c, http.StatusOK, "System image setting saved successfully", setting)
+	utils.Success(c, http.StatusOK, "System image setting saved successfully", saved)
 }
 
 func (h *SystemSettingsHandler) DeleteSystemImageSetting(c *gin.Context) {
-	instanceType := c.Param("instanceType")
-	if err := h.systemImageSettingService.Delete(instanceType); err != nil {
-		utils.HandleError(c, err)
-		return
+	target := strings.TrimSpace(c.Param("instanceType"))
+	if id, err := strconv.Atoi(target); err == nil {
+		if err := h.systemImageSettingService.DeleteByID(id); err != nil {
+			utils.HandleError(c, err)
+			return
+		}
+	} else {
+		if err := h.systemImageSettingService.DisableType(target); err != nil {
+			utils.HandleError(c, err)
+			return
+		}
 	}
 
 	utils.Success(c, http.StatusOK, "System image setting deleted successfully", nil)

--- a/backend/internal/repository/system_image_setting_repository.go
+++ b/backend/internal/repository/system_image_setting_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"clawreef/internal/models"
@@ -12,8 +13,10 @@ import (
 // SystemImageSettingRepository defines repository operations for runtime image settings.
 type SystemImageSettingRepository interface {
 	List() ([]models.SystemImageSetting, error)
-	GetByInstanceType(instanceType string) (*models.SystemImageSetting, error)
-	Upsert(setting *models.SystemImageSetting) error
+	GetByID(id int) (*models.SystemImageSetting, error)
+	ListByInstanceType(instanceType string) ([]models.SystemImageSetting, error)
+	Save(setting *models.SystemImageSetting) error
+	DeleteByID(id int) error
 	DeleteByInstanceType(instanceType string) error
 }
 
@@ -32,7 +35,7 @@ func (r *systemImageSettingRepository) ensureTable() {
 	const query = `
 CREATE TABLE IF NOT EXISTS system_image_settings (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  instance_type VARCHAR(50) NOT NULL UNIQUE,
+  instance_type VARCHAR(50) NOT NULL,
   display_name VARCHAR(255) NOT NULL,
   image VARCHAR(500) NOT NULL,
   is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
@@ -46,6 +49,12 @@ CREATE TABLE IF NOT EXISTS system_image_settings (
 		panic(fmt.Errorf("failed to ensure system_image_settings table: %w", err))
 	}
 
+	r.ensureIsEnabledColumn()
+	r.ensureInstanceTypeIsNotUnique()
+	r.ensureInstanceTypeIndex()
+}
+
+func (r *systemImageSettingRepository) ensureIsEnabledColumn() {
 	var count int
 	row, err := r.sess.SQL().QueryRow(`
 SELECT COUNT(*)
@@ -68,65 +77,142 @@ WHERE table_schema = DATABASE()
 	}
 }
 
+func (r *systemImageSettingRepository) ensureInstanceTypeIsNotUnique() {
+	rows, err := r.sess.SQL().Query(`
+SELECT DISTINCT INDEX_NAME
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name = 'system_image_settings'
+  AND column_name = 'instance_type'
+  AND NON_UNIQUE = 0
+  AND INDEX_NAME <> 'PRIMARY'
+`)
+	if err != nil {
+		panic(fmt.Errorf("failed to inspect system_image_settings indexes: %w", err))
+	}
+	defer rows.Close()
+
+	var indexNames []string
+	for rows.Next() {
+		var indexName string
+		if err := rows.Scan(&indexName); err != nil {
+			panic(fmt.Errorf("failed to scan system_image_settings unique index: %w", err))
+		}
+		indexNames = append(indexNames, indexName)
+	}
+
+	for _, indexName := range indexNames {
+		escapedName := strings.ReplaceAll(indexName, "`", "``")
+		statement := fmt.Sprintf("ALTER TABLE system_image_settings DROP INDEX `%s`", escapedName)
+		if _, err := r.sess.SQL().Exec(statement); err != nil {
+			panic(fmt.Errorf("failed to drop unique instance_type index %s: %w", indexName, err))
+		}
+	}
+}
+
+func (r *systemImageSettingRepository) ensureInstanceTypeIndex() {
+	var count int
+	row, err := r.sess.SQL().QueryRow(`
+SELECT COUNT(*)
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name = 'system_image_settings'
+  AND index_name = 'idx_instance_type'
+`)
+	if err != nil {
+		panic(fmt.Errorf("failed to inspect system_image_settings idx_instance_type index: %w", err))
+	}
+	if err := row.Scan(&count); err != nil {
+		panic(fmt.Errorf("failed to scan system_image_settings idx_instance_type index count: %w", err))
+	}
+
+	if count == 0 {
+		if _, err := r.sess.SQL().Exec("CREATE INDEX idx_instance_type ON system_image_settings (instance_type)"); err != nil {
+			panic(fmt.Errorf("failed to create idx_instance_type index: %w", err))
+		}
+	}
+}
+
 func (r *systemImageSettingRepository) List() ([]models.SystemImageSetting, error) {
 	var settings []models.SystemImageSetting
-	if err := r.sess.Collection("system_image_settings").Find().OrderBy("instance_type").All(&settings); err != nil {
+	if err := r.sess.Collection("system_image_settings").Find().OrderBy("instance_type", "-updated_at", "-id").All(&settings); err != nil {
 		return nil, fmt.Errorf("failed to list system image settings: %w", err)
 	}
 	return settings, nil
 }
 
-func (r *systemImageSettingRepository) GetByInstanceType(instanceType string) (*models.SystemImageSetting, error) {
+func (r *systemImageSettingRepository) GetByID(id int) (*models.SystemImageSetting, error) {
 	var setting models.SystemImageSetting
-	err := r.sess.Collection("system_image_settings").Find(db.Cond{"instance_type": instanceType}).One(&setting)
+	err := r.sess.Collection("system_image_settings").Find(db.Cond{"id": id}).One(&setting)
 	if err != nil {
 		if err == db.ErrNoMoreRows {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to get system image setting: %w", err)
+		return nil, fmt.Errorf("failed to get system image setting by id: %w", err)
 	}
 	return &setting, nil
 }
 
-func (r *systemImageSettingRepository) Upsert(setting *models.SystemImageSetting) error {
-	existing, err := r.GetByInstanceType(setting.InstanceType)
-	if err != nil {
-		return err
+func (r *systemImageSettingRepository) ListByInstanceType(instanceType string) ([]models.SystemImageSetting, error) {
+	var settings []models.SystemImageSetting
+	if err := r.sess.Collection("system_image_settings").Find(db.Cond{"instance_type": instanceType}).OrderBy("-updated_at", "-id").All(&settings); err != nil {
+		return nil, fmt.Errorf("failed to list system image settings by instance type: %w", err)
 	}
+	return settings, nil
+}
 
+func (r *systemImageSettingRepository) Save(setting *models.SystemImageSetting) error {
 	now := time.Now()
-	if existing == nil {
-		if !setting.IsEnabled {
-			setting.IsEnabled = false
+	if setting.ID > 0 {
+		existing, err := r.GetByID(setting.ID)
+		if err != nil {
+			return err
 		}
-		setting.CreatedAt = now
-		setting.UpdatedAt = now
-		if _, err := r.sess.Collection("system_image_settings").Insert(setting); err != nil {
-			return fmt.Errorf("failed to create system image setting: %w", err)
+		if existing == nil {
+			return fmt.Errorf("system image setting not found")
 		}
+
+		existing.InstanceType = setting.InstanceType
+		existing.DisplayName = setting.DisplayName
+		existing.Image = setting.Image
+		existing.IsEnabled = setting.IsEnabled
+		existing.UpdatedAt = now
+		if err := r.sess.Collection("system_image_settings").Find(db.Cond{"id": existing.ID}).Update(existing); err != nil {
+			return fmt.Errorf("failed to update system image setting: %w", err)
+		}
+
+		*setting = *existing
 		return nil
 	}
 
-	existing.DisplayName = setting.DisplayName
-	existing.Image = setting.Image
-	existing.IsEnabled = setting.IsEnabled
-	existing.UpdatedAt = now
-	if err := r.sess.Collection("system_image_settings").Find(db.Cond{"id": existing.ID}).Update(existing); err != nil {
-		return fmt.Errorf("failed to update system image setting: %w", err)
+	setting.CreatedAt = now
+	setting.UpdatedAt = now
+	res, err := r.sess.Collection("system_image_settings").Insert(setting)
+	if err != nil {
+		return fmt.Errorf("failed to create system image setting: %w", err)
+	}
+	if id, ok := res.ID().(int64); ok {
+		setting.ID = int(id)
+	}
+	return nil
+}
+
+func (r *systemImageSettingRepository) DeleteByID(id int) error {
+	if err := r.sess.Collection("system_image_settings").Find(db.Cond{"id": id}).Delete(); err != nil {
+		if err == db.ErrNoMoreRows {
+			return nil
+		}
+		return fmt.Errorf("failed to delete system image setting by id: %w", err)
 	}
 	return nil
 }
 
 func (r *systemImageSettingRepository) DeleteByInstanceType(instanceType string) error {
-	existing, err := r.GetByInstanceType(instanceType)
-	if err != nil {
-		return err
-	}
-	if existing == nil {
-		return nil
-	}
-	if err := r.sess.Collection("system_image_settings").Find(db.Cond{"id": existing.ID}).Delete(); err != nil {
-		return fmt.Errorf("failed to delete system image setting: %w", err)
+	if err := r.sess.Collection("system_image_settings").Find(db.Cond{"instance_type": instanceType}).Delete(); err != nil {
+		if err == db.ErrNoMoreRows {
+			return nil
+		}
+		return fmt.Errorf("failed to delete system image settings by instance type: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/services/system_image_setting_service.go
+++ b/backend/internal/services/system_image_setting_service.go
@@ -55,8 +55,9 @@ func SetRuntimeImageSettingsProvider(provider RuntimeImageSettingsProvider) {
 
 type SystemImageSettingService interface {
 	List() ([]models.SystemImageSetting, error)
-	Save(setting *models.SystemImageSetting) error
-	Delete(instanceType string) error
+	Save(setting *models.SystemImageSetting) (*models.SystemImageSetting, error)
+	DeleteByID(id int) error
+	DisableType(instanceType string) error
 	GetRuntimeImage(instanceType string) (string, bool)
 }
 
@@ -75,94 +76,150 @@ func (s *systemImageSettingService) List() ([]models.SystemImageSetting, error) 
 		return nil, err
 	}
 
-	byType := make(map[string]models.SystemImageSetting, len(stored))
+	byType := make(map[string][]models.SystemImageSetting, len(orderedSystemImageTypes))
 	for _, item := range stored {
-		byType[item.InstanceType] = item
+		normalizedType := strings.TrimSpace(strings.ToLower(item.InstanceType))
+		item.InstanceType = normalizedType
+		if strings.TrimSpace(item.DisplayName) == "" {
+			item.DisplayName = displayNameForSystemImageType(normalizedType)
+		}
+		byType[normalizedType] = append(byType[normalizedType], item)
 	}
 
-	settings := make([]models.SystemImageSetting, 0, len(orderedSystemImageTypes))
+	settings := make([]models.SystemImageSetting, 0, len(stored)+len(orderedSystemImageTypes))
 	for _, instanceType := range orderedSystemImageTypes {
-		displayName := supportedSystemImageTypes[instanceType]
-		if storedItem, ok := byType[instanceType]; ok {
-			if strings.TrimSpace(storedItem.DisplayName) == "" {
-				storedItem.DisplayName = displayName
-			}
-			settings = append(settings, storedItem)
+		items := byType[instanceType]
+		if len(items) == 0 {
+			settings = append(settings, models.SystemImageSetting{
+				InstanceType: instanceType,
+				DisplayName:  displayNameForSystemImageType(instanceType),
+				Image:        defaultSystemImageSettings[instanceType],
+				IsEnabled:    defaultEnabledSystemImageTypes[instanceType],
+			})
 			continue
 		}
 
-		settings = append(settings, models.SystemImageSetting{
-			InstanceType: instanceType,
-			DisplayName:  displayName,
-			Image:        defaultSystemImageSettings[instanceType],
-			IsEnabled:    defaultEnabledSystemImageTypes[instanceType],
-		})
+		for _, item := range items {
+			if item.IsEnabled {
+				settings = append(settings, item)
+			}
+		}
+		delete(byType, instanceType)
+	}
+
+	for instanceType, items := range byType {
+		for _, item := range items {
+			if item.IsEnabled {
+				if strings.TrimSpace(item.DisplayName) == "" {
+					item.DisplayName = displayNameForSystemImageType(instanceType)
+				}
+				settings = append(settings, item)
+			}
+		}
 	}
 
 	return settings, nil
 }
 
-func (s *systemImageSettingService) Save(setting *models.SystemImageSetting) error {
-	setting.InstanceType = strings.TrimSpace(strings.ToLower(setting.InstanceType))
-	if _, ok := supportedSystemImageTypes[setting.InstanceType]; !ok {
-		return errors.New("unsupported instance type")
-	}
-
-	setting.Image = strings.TrimSpace(setting.Image)
-	if setting.Image == "" {
-		return errors.New("image is required")
-	}
-
-	if strings.TrimSpace(setting.DisplayName) == "" {
-		setting.DisplayName = supportedSystemImageTypes[setting.InstanceType]
-	}
-	setting.IsEnabled = true
-
-	return s.repo.Upsert(setting)
-}
-
-func (s *systemImageSettingService) Delete(instanceType string) error {
-	instanceType = strings.TrimSpace(strings.ToLower(instanceType))
-	if _, ok := supportedSystemImageTypes[instanceType]; !ok {
-		return errors.New("unsupported instance type")
-	}
-
-	existing, err := s.repo.GetByInstanceType(instanceType)
-	if err != nil {
-		return err
-	}
-
-	if existing == nil {
-		return s.repo.Upsert(&models.SystemImageSetting{
-			InstanceType: instanceType,
-			DisplayName:  supportedSystemImageTypes[instanceType],
-			Image:        defaultSystemImageSettings[instanceType],
-			IsEnabled:    false,
-		})
-	}
-
-	existing.IsEnabled = false
-	return s.repo.Upsert(existing)
-}
-
-func (s *systemImageSettingService) GetRuntimeImage(instanceType string) (string, bool) {
-	instanceType = strings.TrimSpace(strings.ToLower(instanceType))
-	setting, err := s.repo.GetByInstanceType(instanceType)
-	if err != nil {
-		return "", false
-	}
-
-	if setting == nil {
-		image := strings.TrimSpace(defaultSystemImageSettings[instanceType])
-		return image, image != "" && defaultEnabledSystemImageTypes[instanceType]
-	}
-
-	if !setting.IsEnabled {
-		return "", false
+func (s *systemImageSettingService) Save(setting *models.SystemImageSetting) (*models.SystemImageSetting, error) {
+	normalizedType := strings.TrimSpace(strings.ToLower(setting.InstanceType))
+	if _, ok := supportedSystemImageTypes[normalizedType]; !ok {
+		return nil, errors.New("unsupported instance type")
 	}
 
 	image := strings.TrimSpace(setting.Image)
-	return image, image != ""
+	if image == "" {
+		return nil, errors.New("image is required")
+	}
+
+	setting.InstanceType = normalizedType
+	setting.Image = image
+	setting.DisplayName = strings.TrimSpace(setting.DisplayName)
+	if setting.DisplayName == "" {
+		setting.DisplayName = supportedSystemImageTypes[normalizedType]
+	}
+	setting.IsEnabled = true
+
+	if err := s.repo.Save(setting); err != nil {
+		return nil, err
+	}
+
+	return setting, nil
+}
+
+func (s *systemImageSettingService) DeleteByID(id int) error {
+	if id <= 0 {
+		return errors.New("invalid image setting id")
+	}
+
+	existing, err := s.repo.GetByID(id)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return nil
+	}
+
+	if err := s.repo.DeleteByID(id); err != nil {
+		return err
+	}
+
+	remaining, err := s.repo.ListByInstanceType(existing.InstanceType)
+	if err != nil {
+		return err
+	}
+	if len(remaining) > 0 || !isSupportedSystemImageType(existing.InstanceType) {
+		return nil
+	}
+
+	return s.disableTypeWithFallback(existing.InstanceType)
+}
+
+func (s *systemImageSettingService) DisableType(instanceType string) error {
+	normalizedType := strings.TrimSpace(strings.ToLower(instanceType))
+	if !isSupportedSystemImageType(normalizedType) {
+		return errors.New("unsupported instance type")
+	}
+
+	return s.disableTypeWithFallback(normalizedType)
+}
+
+func (s *systemImageSettingService) disableTypeWithFallback(instanceType string) error {
+	if err := s.repo.DeleteByInstanceType(instanceType); err != nil {
+		return err
+	}
+
+	return s.repo.Save(&models.SystemImageSetting{
+		InstanceType: instanceType,
+		DisplayName:  displayNameForSystemImageType(instanceType),
+		Image:        defaultSystemImageSettings[instanceType],
+		IsEnabled:    false,
+	})
+}
+
+func (s *systemImageSettingService) GetRuntimeImage(instanceType string) (string, bool) {
+	normalizedType := strings.TrimSpace(strings.ToLower(instanceType))
+	items, err := s.repo.ListByInstanceType(normalizedType)
+	if err != nil {
+		return "", false
+	}
+
+	if len(items) == 0 {
+		image := strings.TrimSpace(defaultSystemImageSettings[normalizedType])
+		return image, image != "" && defaultEnabledSystemImageTypes[normalizedType]
+	}
+
+	for _, item := range items {
+		if !item.IsEnabled {
+			continue
+		}
+		image := strings.TrimSpace(item.Image)
+		if image != "" {
+			return image, true
+		}
+	}
+
+	return "", false
 }
 
 func runtimeImageOverride(instanceType string) (string, bool) {
@@ -177,4 +234,9 @@ func displayNameForSystemImageType(instanceType string) string {
 		return name
 	}
 	return fmt.Sprintf("%s Image", instanceType)
+}
+
+func isSupportedSystemImageType(instanceType string) bool {
+	_, ok := supportedSystemImageTypes[instanceType]
+	return ok
 }

--- a/backend/internal/services/system_image_setting_service_test.go
+++ b/backend/internal/services/system_image_setting_service_test.go
@@ -1,0 +1,148 @@
+package services
+
+import (
+	"testing"
+
+	"clawreef/internal/models"
+)
+
+type stubSystemImageSettingRepository struct {
+	items  []models.SystemImageSetting
+	nextID int
+}
+
+func (r *stubSystemImageSettingRepository) List() ([]models.SystemImageSetting, error) {
+	out := make([]models.SystemImageSetting, len(r.items))
+	copy(out, r.items)
+	return out, nil
+}
+
+func (r *stubSystemImageSettingRepository) GetByID(id int) (*models.SystemImageSetting, error) {
+	for _, item := range r.items {
+		if item.ID == id {
+			copyItem := item
+			return &copyItem, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *stubSystemImageSettingRepository) ListByInstanceType(instanceType string) ([]models.SystemImageSetting, error) {
+	var out []models.SystemImageSetting
+	for _, item := range r.items {
+		if item.InstanceType == instanceType {
+			out = append(out, item)
+		}
+	}
+	return out, nil
+}
+
+func (r *stubSystemImageSettingRepository) Save(setting *models.SystemImageSetting) error {
+	if setting.ID > 0 {
+		for i := range r.items {
+			if r.items[i].ID == setting.ID {
+				r.items[i] = *setting
+				return nil
+			}
+		}
+	}
+
+	r.nextID++
+	copyItem := *setting
+	copyItem.ID = r.nextID
+	*setting = copyItem
+	r.items = append(r.items, copyItem)
+	return nil
+}
+
+func (r *stubSystemImageSettingRepository) DeleteByID(id int) error {
+	filtered := r.items[:0]
+	for _, item := range r.items {
+		if item.ID != id {
+			filtered = append(filtered, item)
+		}
+	}
+	r.items = filtered
+	return nil
+}
+
+func (r *stubSystemImageSettingRepository) DeleteByInstanceType(instanceType string) error {
+	filtered := r.items[:0]
+	for _, item := range r.items {
+		if item.InstanceType != instanceType {
+			filtered = append(filtered, item)
+		}
+	}
+	r.items = filtered
+	return nil
+}
+
+func TestSystemImageSettingServiceListAllowsMultipleImagesPerType(t *testing.T) {
+	repo := &stubSystemImageSettingRepository{
+		items: []models.SystemImageSetting{
+			{ID: 1, InstanceType: "openclaw", DisplayName: "OpenClaw Stable", Image: "registry/openclaw:stable", IsEnabled: true},
+			{ID: 2, InstanceType: "openclaw", DisplayName: "OpenClaw Canary", Image: "registry/openclaw:canary", IsEnabled: true},
+			{ID: 3, InstanceType: "ubuntu", DisplayName: "Ubuntu Desktop", Image: "lscr.io/linuxserver/webtop:ubuntu-xfce", IsEnabled: false},
+		},
+		nextID: 3,
+	}
+
+	service := NewSystemImageSettingService(repo)
+	items, err := service.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+
+	openClawCount := 0
+	for _, item := range items {
+		if item.InstanceType == "openclaw" {
+			openClawCount++
+		}
+	}
+
+	if openClawCount != 2 {
+		t.Fatalf("expected 2 openclaw runtime images, got %d", openClawCount)
+	}
+}
+
+func TestSystemImageSettingServiceDeleteByIDCreatesDisabledFallback(t *testing.T) {
+	repo := &stubSystemImageSettingRepository{
+		items: []models.SystemImageSetting{
+			{ID: 1, InstanceType: "openclaw", DisplayName: "OpenClaw Stable", Image: "registry/openclaw:stable", IsEnabled: true},
+		},
+		nextID: 1,
+	}
+
+	service := NewSystemImageSettingService(repo)
+	if err := service.DeleteByID(1); err != nil {
+		t.Fatalf("DeleteByID returned error: %v", err)
+	}
+
+	items, err := repo.ListByInstanceType("openclaw")
+	if err != nil {
+		t.Fatalf("ListByInstanceType returned error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 fallback row after deleting last image, got %d", len(items))
+	}
+	if items[0].IsEnabled {
+		t.Fatalf("expected fallback row to be disabled")
+	}
+
+	image, ok := service.GetRuntimeImage("openclaw")
+	if ok || image != "" {
+		t.Fatalf("expected runtime image lookup to be disabled after fallback, got %q %v", image, ok)
+	}
+}
+
+func TestSystemImageSettingServiceGetRuntimeImageFallsBackToDefaultWhenNoRowsExist(t *testing.T) {
+	service := NewSystemImageSettingService(&stubSystemImageSettingRepository{})
+
+	image, ok := service.GetRuntimeImage("openclaw")
+	if !ok {
+		t.Fatalf("expected default openclaw runtime image to be available")
+	}
+	if image != defaultSystemImageSettings["openclaw"] {
+		t.Fatalf("expected default openclaw image %q, got %q", defaultSystemImageSettings["openclaw"], image)
+	}
+}

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1483,6 +1483,8 @@ export const translations: Record<Locale, TranslationTree> = {
       loadFailed: "Failed to load image settings",
       requiredFields: "Instance type and image are required.",
       duplicateType: "This instance type already has a card.",
+      duplicateImage:
+        "This runtime image already exists under the selected instance type.",
       saveFailed: "Failed to save image setting",
       deleteFailed: "Failed to delete image setting",
       runtimeImageCards: "Runtime Image Cards",
@@ -1585,6 +1587,10 @@ export const translations: Record<Locale, TranslationTree> = {
         "Are you sure you want to delete this instance? This action cannot be undone.",
       details: "Details",
       instanceImage: "Instance Image",
+      runtimeImageSelectionHint:
+        "Choose which runtime image version should be used for this instance type.",
+      runtimeImageUnavailable:
+        "No enabled runtime image is currently available for this instance type.",
       operatingSystem: "Operating System",
       access: "Access",
       portalView: "Portal View",
@@ -2645,6 +2651,7 @@ export const translations: Record<Locale, TranslationTree> = {
       loadFailed: "加载镜像设置失败",
       requiredFields: "实例类型和镜像地址为必填项。",
       duplicateType: "这个实例类型已经有一张卡片。",
+      duplicateImage: "该实例类型下已经存在相同的运行时镜像。",
       saveFailed: "保存镜像设置失败",
       deleteFailed: "删除镜像设置失败",
       runtimeImageCards: "运行时镜像卡片",
@@ -2741,6 +2748,8 @@ export const translations: Record<Locale, TranslationTree> = {
       confirmDelete: "确定要删除这个实例吗？此操作不可撤销。",
       details: "详情",
       instanceImage: "实例镜像",
+      runtimeImageSelectionHint: "选择该实例类型实际要使用的运行时镜像版本。",
+      runtimeImageUnavailable: "当前这个实例类型没有可用的运行时镜像。",
       operatingSystem: "操作系统",
       access: "访问",
       portalView: "门户视图",
@@ -3791,6 +3800,8 @@ export const translations: Record<Locale, TranslationTree> = {
       loadFailed: "イメージ設定の読み込みに失敗しました",
       requiredFields: "インスタンスタイプとイメージは必須です。",
       duplicateType: "このインスタンスタイプには既にカードがあります。",
+      duplicateImage:
+        "選択したインスタンスタイプには同じランタイムイメージが既に存在します。",
       saveFailed: "イメージ設定の保存に失敗しました",
       deleteFailed: "イメージ設定の削除に失敗しました",
       runtimeImageCards: "ランタイムイメージカード",
@@ -3893,6 +3904,10 @@ export const translations: Record<Locale, TranslationTree> = {
         "このインスタンスを削除してもよろしいですか？この操作は元に戻せません。",
       details: "詳細",
       instanceImage: "インスタンスイメージ",
+      runtimeImageSelectionHint:
+        "このインスタンスタイプで使用するランタイムイメージのバージョンを選択してください。",
+      runtimeImageUnavailable:
+        "このインスタンスタイプで利用可能なランタイムイメージは現在ありません。",
       operatingSystem: "オペレーティングシステム",
       access: "アクセス",
       portalView: "ポータル表示",
@@ -4979,6 +4994,8 @@ export const translations: Record<Locale, TranslationTree> = {
       loadFailed: "이미지 설정을 불러오지 못했습니다",
       requiredFields: "인스턴스 유형과 이미지는 필수입니다.",
       duplicateType: "이 인스턴스 유형에는 이미 카드가 있습니다.",
+      duplicateImage:
+        "선택한 인스턴스 유형에 동일한 런타임 이미지가 이미 있습니다.",
       saveFailed: "이미지 설정을 저장하지 못했습니다",
       deleteFailed: "이미지 설정을 삭제하지 못했습니다",
       runtimeImageCards: "런타임 이미지 카드",
@@ -5078,6 +5095,10 @@ export const translations: Record<Locale, TranslationTree> = {
         "이 인스턴스를 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
       details: "세부정보",
       instanceImage: "인스턴스 이미지",
+      runtimeImageSelectionHint:
+        "이 인스턴스 유형에 사용할 런타임 이미지 버전을 선택하세요.",
+      runtimeImageUnavailable:
+        "이 인스턴스 유형에 현재 사용할 수 있는 런타임 이미지가 없습니다.",
       operatingSystem: "운영체제",
       access: "접속",
       portalView: "포털 보기",
@@ -6169,6 +6190,8 @@ export const translations: Record<Locale, TranslationTree> = {
       loadFailed: "Bildeinstellungen konnten nicht geladen werden",
       requiredFields: "Instanztyp und Image sind erforderlich.",
       duplicateType: "Für diesen Instanztyp existiert bereits eine Karte.",
+      duplicateImage:
+        "Dieses Runtime-Image existiert für den gewählten Instanztyp bereits.",
       saveFailed: "Bildeinstellung konnte nicht gespeichert werden",
       deleteFailed: "Bildeinstellung konnte nicht gelöscht werden",
       runtimeImageCards: "Runtime-Image-Karten",
@@ -6272,6 +6295,10 @@ export const translations: Record<Locale, TranslationTree> = {
         "Möchten Sie diese Instanz wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
       details: "Details",
       instanceImage: "Instanz-Image",
+      runtimeImageSelectionHint:
+        "Wählen Sie aus, welche Runtime-Image-Version für diesen Instanztyp verwendet werden soll.",
+      runtimeImageUnavailable:
+        "Für diesen Instanztyp ist derzeit kein aktiviertes Runtime-Image verfügbar.",
       operatingSystem: "Betriebssystem",
       access: "Zugriff",
       portalView: "Portalansicht",

--- a/frontend/src/pages/admin/SystemSettingsPage.tsx
+++ b/frontend/src/pages/admin/SystemSettingsPage.tsx
@@ -97,9 +97,14 @@ const SystemSettingsPage: React.FC = () => {
       return;
     }
 
-    const duplicate = cards.some((item) => item.local_id !== card.local_id && item.instance_type === card.instance_type);
+    const normalizedImage = card.image.trim().toLowerCase();
+    const duplicate = cards.some((item) =>
+      item.local_id !== card.local_id &&
+      item.instance_type === card.instance_type &&
+      item.image.trim().toLowerCase() === normalizedImage,
+    );
     if (duplicate) {
-      updateCard(card.local_id, { error: t('systemSettingsPage.duplicateType') });
+      updateCard(card.local_id, { error: t('systemSettingsPage.duplicateImage') });
       return;
     }
 
@@ -107,6 +112,7 @@ const SystemSettingsPage: React.FC = () => {
 
     try {
       const saved = await systemSettingsService.saveImageSetting({
+        id: card.id,
         instance_type: card.instance_type,
         display_name: card.display_name,
         image: card.image.trim(),
@@ -136,7 +142,7 @@ const SystemSettingsPage: React.FC = () => {
 
     updateCard(card.local_id, { saving: true, error: null });
     try {
-      await systemSettingsService.deleteImageSetting(card.instance_type);
+      await systemSettingsService.deleteImageSetting(card.id ?? card.instance_type);
       setCards((current) => current.filter((item) => item.local_id !== card.local_id));
     } catch (error: any) {
       updateCard(card.local_id, {
@@ -178,10 +184,6 @@ const SystemSettingsPage: React.FC = () => {
           ) : (
             <div className="mt-6 grid grid-cols-1 gap-4 xl:grid-cols-2">
               {cards.map((card) => {
-                const selectableTypes = IMAGE_TYPE_OPTIONS.filter((option) => (
-                  option.value === card.instance_type || !usedTypes.includes(option.value)
-                ));
-
                 const defaultImage = IMAGE_TYPE_OPTIONS.find((option) => option.value === card.instance_type)?.defaultImage ?? '-';
 
                 return (
@@ -194,7 +196,7 @@ const SystemSettingsPage: React.FC = () => {
                           onChange={(event) => updateCard(card.local_id, { instance_type: event.target.value })}
                           className="app-input mt-1 block w-full"
                         >
-                          {selectableTypes.map((option) => (
+                          {IMAGE_TYPE_OPTIONS.map((option) => (
                             <option key={option.value} value={option.value}>
                               {option.label}
                             </option>

--- a/frontend/src/pages/instances/CreateInstancePage.tsx
+++ b/frontend/src/pages/instances/CreateInstancePage.tsx
@@ -16,7 +16,10 @@ import type { OpenClawConfigCompilePreview } from "../../types/openclawConfig";
 import type { Skill } from "../../types/skill";
 import type { UserQuota } from "../../types/user";
 import { useI18n } from "../../contexts/I18nContext";
-import { systemSettingsService } from "../../services/systemSettingsService";
+import {
+  systemSettingsService,
+  type SystemImageSetting,
+} from "../../services/systemSettingsService";
 
 type BuiltInEnvTemplate = {
   key: string;
@@ -259,6 +262,11 @@ const getPresetDescription = (
   return keys ? t(keys.description) : fallback;
 };
 
+const getRuntimeImageOptionKey = (item: SystemImageSetting): string =>
+  item.id != null
+    ? `runtime-image:${item.id}`
+    : `runtime-image:${item.instance_type}:${item.image}`;
+
 const CreateInstancePage: React.FC = () => {
   const { user } = useAuth();
   const { t } = useI18n();
@@ -269,6 +277,10 @@ const CreateInstancePage: React.FC = () => {
   const [step, setStep] = useState(1);
   const [submitArmed, setSubmitArmed] = useState(false);
   const [availableTypes, setAvailableTypes] = useState(INSTANCE_TYPES);
+  const [runtimeImageSettings, setRuntimeImageSettings] = useState<
+    SystemImageSetting[]
+  >([]);
+  const [selectedRuntimeImageKey, setSelectedRuntimeImageKey] = useState("");
   const [quota, setQuota] = useState<UserQuota | null>(null);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [openClawImportFile, setOpenClawImportFile] = useState<File | null>(
@@ -326,6 +338,13 @@ const CreateInstancePage: React.FC = () => {
       !Object.prototype.hasOwnProperty.call(builtinEnvOverrides, template.key),
   );
   const selectedType = availableTypes.find((item) => item.id === formData.type);
+  const runtimeImageOptions = runtimeImageSettings.filter(
+    (item) => item.is_enabled !== false && item.instance_type === formData.type,
+  );
+  const selectedRuntimeImage =
+    runtimeImageOptions.find(
+      (item) => getRuntimeImageOptionKey(item) === selectedRuntimeImageKey,
+    ) ?? runtimeImageOptions[0] ?? null;
 
   const getCreateErrorMessage = (rawError?: string) => {
     if (rawError === "instance name already exists") {
@@ -338,10 +357,10 @@ const CreateInstancePage: React.FC = () => {
     const loadAvailableTypes = async () => {
       try {
         const items = await systemSettingsService.getImageSettings();
+        const enabledItems = items.filter((item) => item.is_enabled !== false);
+        setRuntimeImageSettings(enabledItems);
         const enabledTypes = new Set(
-          items
-            .filter((item) => item.is_enabled !== false)
-            .map((item) => item.instance_type),
+          enabledItems.map((item) => item.instance_type),
         );
 
         const filtered = INSTANCE_TYPES.filter((type) =>
@@ -362,8 +381,11 @@ const CreateInstancePage: React.FC = () => {
               os_version: first.defaultVersion,
             };
           });
+        } else {
+          setAvailableTypes([]);
         }
       } catch {
+        setRuntimeImageSettings([]);
         setAvailableTypes(INSTANCE_TYPES);
       }
     };
@@ -393,6 +415,21 @@ const CreateInstancePage: React.FC = () => {
 
     void loadSkills();
   }, []);
+
+  useEffect(() => {
+    if (runtimeImageOptions.length === 0) {
+      setSelectedRuntimeImageKey("");
+      return;
+    }
+
+    setSelectedRuntimeImageKey((current) =>
+      runtimeImageOptions.some(
+        (item) => getRuntimeImageOptionKey(item) === current,
+      )
+        ? current
+        : getRuntimeImageOptionKey(runtimeImageOptions[0]),
+    );
+  }, [runtimeImageOptions]);
 
   useEffect(() => {
     const nextTotalPages = Math.max(
@@ -584,6 +621,8 @@ const CreateInstancePage: React.FC = () => {
       setError(null);
       const createPayload: CreateInstanceRequest = {
         ...formData,
+        image_registry: selectedRuntimeImage?.image,
+        image_tag: selectedRuntimeImage ? undefined : formData.image_tag,
         environment_overrides: overrides,
         skill_ids: formData.type === "openclaw" ? selectedSkillIds : undefined,
         openclaw_config_plan:
@@ -624,7 +663,7 @@ const CreateInstancePage: React.FC = () => {
 
   const canProceed = () => {
     if (step === 1) return formData.name.length >= 3;
-    if (step === 2) return true;
+    if (step === 2) return availableTypes.length > 0;
     return true;
   };
 
@@ -1007,6 +1046,66 @@ const CreateInstancePage: React.FC = () => {
                     )}
                   </div>
                 ))}
+              </div>
+
+              <div className="mt-6 rounded-[24px] border border-[#ead8cf] bg-[rgba(255,248,245,0.72)] p-5">
+                <div>
+                  <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-[#b46c50]">
+                    {t("instances.instanceImage")}
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    {t("instances.runtimeImageSelectionHint")}
+                  </p>
+                </div>
+
+                {runtimeImageOptions.length === 0 ? (
+                  <p className="mt-4 text-sm text-gray-500">
+                    {t("instances.runtimeImageUnavailable")}
+                  </p>
+                ) : (
+                  <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-2">
+                    {runtimeImageOptions.map((item) => {
+                      const optionKey = getRuntimeImageOptionKey(item);
+                      const selected = optionKey === selectedRuntimeImageKey;
+
+                      return (
+                        <button
+                          key={optionKey}
+                          type="button"
+                          onClick={() => setSelectedRuntimeImageKey(optionKey)}
+                          className={`rounded-[20px] border p-4 text-left transition-all hover:-translate-y-0.5 hover:shadow-[0_24px_56px_-42px_rgba(72,44,24,0.55)] ${
+                            selected
+                              ? "border-indigo-500 bg-white ring-2 ring-indigo-500"
+                              : "border-[#ead8cf] bg-white"
+                          }`}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <h4 className="text-sm font-semibold text-gray-900">
+                                {item.display_name}
+                              </h4>
+                              <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[#b46c50]">
+                                {getInstanceTypeLabel(
+                                  t,
+                                  item.instance_type,
+                                  item.instance_type,
+                                )}
+                              </p>
+                            </div>
+                            {selected && (
+                              <span className="rounded-full bg-indigo-100 px-2.5 py-1 text-xs font-medium text-indigo-700">
+                                ✓
+                              </span>
+                            )}
+                          </div>
+                          <p className="mt-3 break-all rounded-2xl bg-[#f8f5f2] px-3 py-2 font-mono text-xs text-[#5f5957]">
+                            {item.image}
+                          </p>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -1797,6 +1896,21 @@ const CreateInstancePage: React.FC = () => {
                             )
                           : formData.type}
                       </dd>
+                    </div>
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">
+                        {t("instances.instanceImage")}
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {selectedRuntimeImage?.display_name ||
+                          selectedRuntimeImage?.image ||
+                          t("instances.runtimeImageUnavailable")}
+                      </dd>
+                      {selectedRuntimeImage?.image && (
+                        <p className="mt-1 break-all font-mono text-xs text-gray-500">
+                          {selectedRuntimeImage.image}
+                        </p>
+                      )}
                     </div>
                     <div>
                       <dt className="text-sm font-medium text-gray-500">

--- a/frontend/src/services/systemSettingsService.ts
+++ b/frontend/src/services/systemSettingsService.ts
@@ -13,7 +13,10 @@ export interface SystemImageSetting {
 export const systemSettingsService = {
   getImageSettings: async (): Promise<SystemImageSetting[]> => {
     const response = await api.get('/system-settings/images');
-    return response.data.data?.items ?? [];
+    return (response.data.data?.items ?? []).map((item: SystemImageSetting) => ({
+      ...item,
+      id: item.id && item.id > 0 ? item.id : undefined,
+    }));
   },
 
   saveImageSetting: async (setting: SystemImageSetting): Promise<SystemImageSetting> => {
@@ -21,7 +24,7 @@ export const systemSettingsService = {
     return response.data.data;
   },
 
-  deleteImageSetting: async (instanceType: string): Promise<void> => {
-    await api.delete(`/system-settings/images/${instanceType}`);
+  deleteImageSetting: async (target: number | string): Promise<void> => {
+    await api.delete(`/system-settings/images/${target}`);
   },
 };


### PR DESCRIPTION
## Summary
- allow multiple runtime image cards for the same instance type
- remove the unique-per-type restriction and save/delete by card id
- let instance creation choose from all enabled runtime image versions