### PR TITLE
fix: renew agent session expiry on each heartbeat

### DIFF
--- a/backend/internal/services/instance_agent_service.go
+++ b/backend/internal/services/instance_agent_service.go
@@ -229,6 +229,13 @@ func (s *instanceAgentService) Heartbeat(session *AgentSession, req AgentHeartbe
 	session.Agent.Status = agentStatusOnline
 	session.Agent.LastHeartbeatAt = &now
 	session.Agent.LastSeenIP = optionalString(strings.TrimSpace(clientIP))
+
+	// Renew session expiry on each successful heartbeat (rolling window).
+	// Without this, the 24-hour session token issued at Register() silently
+	// expires and the agent is permanently locked out until pod restart.
+	newExpiry := now.Add(24 * time.Hour)
+	session.Agent.SessionExpiresAt = &newExpiry
+
 	if err := s.agentRepo.Update(session.Agent); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The agent session token issued during Register() has a fixed 24-hour TTL that is never extended. After exactly 24 hours of continuous operation, AuthenticateSession() rejects the token and every subsequent heartbeat returns 401. Because the agent shim does not detect non-2xx responses, it keeps sending heartbeats silently into the void and the agent appears permanently offline — recoverable only by a full pod restart.

Fix: roll the SessionExpiresAt forward by 24 hours on every successful Heartbeat() call, turning the fixed deadline into a sliding window. As long as the agent keeps heartbeating (every 30s by default), the session never expires.

Discovered in production with 12 openclaw instances going offline simultaneously after exactly 24 hours of uptime.