### PR TITLE
fix: admin sees all users' instances in workspace view

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -199,6 +199,18 @@ func main() {
 			instances.DELETE("/:id/skills/:skillId", skillHandler.RemoveSkillFromInstance)
 		}
 
+		// Admin console: cross-user instance listing. Gated by admin
+		// middleware — non-admin callers get 403. The workspace
+		// /instances endpoint above stays caller-scoped regardless of
+		// role; admin status only unlocks this dedicated surface.
+		adminInstances := api.Group("/admin/instances")
+		adminInstances.Use(middleware.Auth())
+		adminInstances.Use(middleware.SetUserInfo(userRepo))
+		adminInstances.Use(middleware.NewAdminAuth(userRepo))
+		{
+			adminInstances.GET("", instanceHandler.ListAllInstances)
+		}
+
 		openClawConfigs := api.Group("/openclaw-configs")
 		openClawConfigs.Use(middleware.Auth())
 		openClawConfigs.Use(middleware.SetUserInfo(userRepo))

--- a/backend/internal/handlers/instance_handler.go
+++ b/backend/internal/handlers/instance_handler.go
@@ -93,10 +93,14 @@ type ListInstancesRequest struct {
 	Status string `form:"status,omitempty"`
 }
 
-// ListInstances lists instances for the current user
+// ListInstances lists instances owned by the current user (workspace view).
+//
+// This endpoint is always caller-scoped — the caller's role is intentionally
+// not consulted. An admin using /instances sees only instances they personally
+// own. Admin-scoped cross-user listing lives on /admin/instances and is gated
+// by the admin middleware; see ListAllInstances below.
 func (h *InstanceHandler) ListInstances(c *gin.Context) {
 	userID, _ := c.Get("userID")
-	userRole, _ := c.Get("userRole")
 
 	var req ListInstancesRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -107,7 +111,37 @@ func (h *InstanceHandler) ListInstances(c *gin.Context) {
 	// Calculate offset
 	offset := (req.Page - 1) * req.Limit
 
-	instances, total, err := h.instanceService.GetVisibleInstances(userID.(int), fmt.Sprintf("%v", userRole), offset, req.Limit)
+	instances, total, err := h.instanceService.GetByUserID(userID.(int), offset, req.Limit)
+	if err != nil {
+		utils.HandleError(c, err)
+		return
+	}
+
+	response := map[string]interface{}{
+		"instances": instances,
+		"total":     total,
+		"page":      req.Page,
+		"limit":     req.Limit,
+	}
+
+	utils.Success(c, http.StatusOK, "Instances retrieved successfully", response)
+}
+
+// ListAllInstances lists every instance across all users (admin console view).
+//
+// Gated by the admin middleware on the /admin/instances route group. The
+// admin role badge only controls which API surface is reachable — it does
+// not widen the caller-scoped /instances endpoint.
+func (h *InstanceHandler) ListAllInstances(c *gin.Context) {
+	var req ListInstancesRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		utils.ValidationError(c, err)
+		return
+	}
+
+	offset := (req.Page - 1) * req.Limit
+
+	instances, total, err := h.instanceService.GetAllInstances(offset, req.Limit)
 	if err != nil {
 		utils.HandleError(c, err)
 		return

--- a/backend/internal/services/instance_service.go
+++ b/backend/internal/services/instance_service.go
@@ -22,7 +22,7 @@ type InstanceService interface {
 	Create(userID int, req CreateInstanceRequest) (*models.Instance, error)
 	GetByID(id int) (*models.Instance, error)
 	GetByUserID(userID int, offset, limit int) ([]models.Instance, int, error)
-	GetVisibleInstances(userID int, userRole string, offset, limit int) ([]models.Instance, int, error)
+	GetAllInstances(offset, limit int) ([]models.Instance, int, error)
 	Start(instanceID int) error
 	Stop(instanceID int) error
 	Restart(instanceID int) error
@@ -409,22 +409,18 @@ func (s *instanceService) GetByUserID(userID int, offset, limit int) ([]models.I
 	return instances, total, nil
 }
 
-func (s *instanceService) GetVisibleInstances(userID int, userRole string, offset, limit int) ([]models.Instance, int, error) {
-	if strings.EqualFold(strings.TrimSpace(userRole), "admin") {
-		instances, err := s.instanceRepo.GetAll(offset, limit)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		total, err := s.instanceRepo.CountAll()
-		if err != nil {
-			return nil, 0, err
-		}
-
-		return instances, total, nil
+func (s *instanceService) GetAllInstances(offset, limit int) ([]models.Instance, int, error) {
+	instances, err := s.instanceRepo.GetAll(offset, limit)
+	if err != nil {
+		return nil, 0, err
 	}
 
-	return s.GetByUserID(userID, offset, limit)
+	total, err := s.instanceRepo.CountAll()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return instances, total, nil
 }
 
 // Start starts an instance

--- a/backend/internal/services/instance_visibility_test.go
+++ b/backend/internal/services/instance_visibility_test.go
@@ -1,0 +1,159 @@
+package services
+
+import (
+	"testing"
+
+	"clawreef/internal/models"
+)
+
+// stubInstanceVisibilityRepo is a minimal InstanceRepository used by the
+// visibility tests below. It only implements the read paths exercised by
+// GetByUserID / GetAllInstances; every other method panics so that any
+// accidental call surfaces as a test failure instead of a silent stub.
+type stubInstanceVisibilityRepo struct {
+	all []models.Instance
+}
+
+func (r *stubInstanceVisibilityRepo) byUser(userID int) []models.Instance {
+	out := make([]models.Instance, 0, len(r.all))
+	for _, inst := range r.all {
+		if inst.UserID == userID {
+			out = append(out, inst)
+		}
+	}
+	return out
+}
+
+func (r *stubInstanceVisibilityRepo) Create(*models.Instance) error { panic("not used") }
+func (r *stubInstanceVisibilityRepo) GetByID(int) (*models.Instance, error) {
+	panic("not used")
+}
+func (r *stubInstanceVisibilityRepo) GetByAccessToken(string) (*models.Instance, error) {
+	panic("not used")
+}
+func (r *stubInstanceVisibilityRepo) GetByAgentBootstrapToken(string) (*models.Instance, error) {
+	panic("not used")
+}
+func (r *stubInstanceVisibilityRepo) GetAll(offset, limit int) ([]models.Instance, error) {
+	return paginate(r.all, offset, limit), nil
+}
+func (r *stubInstanceVisibilityRepo) CountAll() (int, error) { return len(r.all), nil }
+func (r *stubInstanceVisibilityRepo) GetByUserID(userID, offset, limit int) ([]models.Instance, error) {
+	return paginate(r.byUser(userID), offset, limit), nil
+}
+func (r *stubInstanceVisibilityRepo) CountByUserID(userID int) (int, error) {
+	return len(r.byUser(userID)), nil
+}
+func (r *stubInstanceVisibilityRepo) ExistsByUserIDAndName(int, string) (bool, error) {
+	return false, nil
+}
+func (r *stubInstanceVisibilityRepo) GetAllRunning() ([]models.Instance, error) {
+	return nil, nil
+}
+func (r *stubInstanceVisibilityRepo) Update(*models.Instance) error { panic("not used") }
+func (r *stubInstanceVisibilityRepo) Delete(int) error              { panic("not used") }
+
+func paginate(items []models.Instance, offset, limit int) []models.Instance {
+	if offset >= len(items) {
+		return []models.Instance{}
+	}
+	end := offset + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	out := make([]models.Instance, end-offset)
+	copy(out, items[offset:end])
+	return out
+}
+
+// TestGetByUserIDFiltersByCaller locks in the workspace-view contract: the
+// caller-scoped listing must return only the caller's own instances,
+// regardless of any role the caller may hold elsewhere. Regression guard
+// for the admin-cross-user-leakage bug in which role=admin widened this
+// endpoint to every user's instances.
+func TestGetByUserIDFiltersByCaller(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubInstanceVisibilityRepo{
+		all: []models.Instance{
+			{ID: 1, UserID: 10, Name: "alice-1"},
+			{ID: 2, UserID: 10, Name: "alice-2"},
+			{ID: 3, UserID: 20, Name: "bob-1"},
+		},
+	}
+	svc := &instanceService{instanceRepo: repo}
+
+	instances, total, err := svc.GetByUserID(10, 0, 50)
+	if err != nil {
+		t.Fatalf("GetByUserID returned error: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total=2 for alice, got %d", total)
+	}
+	if len(instances) != 2 || instances[0].Name != "alice-1" || instances[1].Name != "alice-2" {
+		t.Fatalf("expected alice's instances only, got %+v", instances)
+	}
+
+	instances, total, err = svc.GetByUserID(20, 0, 50)
+	if err != nil {
+		t.Fatalf("GetByUserID returned error: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("expected total=1 for bob, got %d", total)
+	}
+	if len(instances) != 1 || instances[0].Name != "bob-1" {
+		t.Fatalf("expected bob's instance only, got %+v", instances)
+	}
+
+	// A user with no instances sees an empty list, never someone else's.
+	instances, total, err = svc.GetByUserID(99, 0, 50)
+	if err != nil {
+		t.Fatalf("GetByUserID returned error: %v", err)
+	}
+	if total != 0 || len(instances) != 0 {
+		t.Fatalf("expected empty listing for user 99, got total=%d instances=%+v", total, instances)
+	}
+}
+
+// TestGetAllInstancesReturnsEveryUser verifies the admin-console surface:
+// cross-user listing, with pagination, independent of caller identity (the
+// admin middleware gates reachability at the route layer, not here).
+func TestGetAllInstancesReturnsEveryUser(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubInstanceVisibilityRepo{
+		all: []models.Instance{
+			{ID: 1, UserID: 10, Name: "alice-1"},
+			{ID: 2, UserID: 10, Name: "alice-2"},
+			{ID: 3, UserID: 20, Name: "bob-1"},
+		},
+	}
+	svc := &instanceService{instanceRepo: repo}
+
+	instances, total, err := svc.GetAllInstances(0, 50)
+	if err != nil {
+		t.Fatalf("GetAllInstances returned error: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("expected total=3 across users, got %d", total)
+	}
+	if len(instances) != 3 {
+		t.Fatalf("expected 3 instances, got %d", len(instances))
+	}
+
+	// Pagination still respected.
+	page1, _, err := svc.GetAllInstances(0, 2)
+	if err != nil {
+		t.Fatalf("GetAllInstances page1 error: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("expected page1 size=2, got %d", len(page1))
+	}
+	page2, _, err := svc.GetAllInstances(2, 2)
+	if err != nil {
+		t.Fatalf("GetAllInstances page2 error: %v", err)
+	}
+	if len(page2) != 1 || page2[0].Name != "bob-1" {
+		t.Fatalf("expected page2=[bob-1], got %+v", page2)
+	}
+}

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import AdminLayout from '../../components/AdminLayout';
 import { userService } from '../../services/userService';
-import { instanceService } from '../../services/instanceService';
+import { adminInstanceService } from '../../services/adminInstanceService';
 import { adminService, type ClusterResourceOverview, type ResourceSummary } from '../../services/adminService';
 import { useI18n } from '../../contexts/I18nContext';
 
@@ -81,7 +81,7 @@ const AdminDashboard: React.FC = () => {
 
         const [usersData, instancesData, clusterData] = await Promise.all([
           userService.getUsers(1, 1000),
-          instanceService.getInstances(1, 1000),
+          adminInstanceService.getInstances(1, 1000),
           adminService.getClusterResources(),
         ]);
 

--- a/frontend/src/pages/admin/InstanceManagementPage.tsx
+++ b/frontend/src/pages/admin/InstanceManagementPage.tsx
@@ -3,6 +3,7 @@ import AdminLayout from '../../components/AdminLayout';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useI18n } from '../../contexts/I18nContext';
 import { instanceService } from '../../services/instanceService';
+import { adminInstanceService } from '../../services/adminInstanceService';
 import { userService } from '../../services/userService';
 import type { Instance } from '../../types/instance';
 import type { User } from '../../types/user';
@@ -28,7 +29,7 @@ const InstanceManagementPage: React.FC = () => {
       setLoading(true);
       setError(null);
       const [instancesData, usersData] = await Promise.all([
-        instanceService.getInstances(1, 1000),
+        adminInstanceService.getInstances(1, 1000),
         userService.getUsers(1, 1000),
       ]);
       setInstances(instancesData.instances || []);

--- a/frontend/src/services/adminInstanceService.ts
+++ b/frontend/src/services/adminInstanceService.ts
@@ -1,0 +1,18 @@
+import api from "./api";
+import type { InstanceListResponse } from "../types/instance";
+
+// adminInstanceService: admin-console surface for cross-user instance
+// listing. Backed by /admin/instances, which is gated by the admin
+// middleware on the backend. The regular instanceService.getInstances
+// hits /instances and is always caller-scoped regardless of role.
+export const adminInstanceService = {
+  getInstances: async (
+    page: number = 1,
+    limit: number = 20,
+  ): Promise<InstanceListResponse> => {
+    const response = await api.get("/admin/instances", {
+      params: { page, limit },
+    });
+    return response.data.data;
+  },
+};


### PR DESCRIPTION
## Problem

Logging in as an admin and opening **Workspace → My Instances** lists every instance in the cluster, including instances owned by other users. Non-admins see only their own instances, as expected. The workspace view is supposed to be caller-scoped regardless of role; the admin console is the place for cross-user listings.

Repro on `main`:
1. Log in as a user with `role = admin`.
2. `GET /api/v1/instances` — response contains instances whose `user_id` is not the caller's.

## Root cause

`InstanceService.GetVisibleInstances(userID, role, offset, limit)` branched on role:

- `role == "admin"` → `instanceRepo.GetAll` (every instance)
- otherwise → `instanceRepo.GetByUserID`

`GET /instances` passed the caller's role into that function, so a single URL had two meanings depending on who called it. Role was doing double duty — gating the admin console UI **and** silently widening the workspace endpoint — and the second job was wrong.

## Fix

Split the two views at the API surface, not inside the service.

**Backend**

- `GET /instances` is now always caller-scoped. The handler calls `GetByUserID` unconditionally and never reads the caller's role.
- `GET /admin/instances` is a new route group gated by the existing admin middleware trio — `middleware.Auth()` + `middleware.SetUserInfo(userRepo)` + `middleware.NewAdminAuth(userRepo)` — the same trio already used by `adminModels`, `adminAIAudit`, `adminCosts`, etc. It calls a new `InstanceService.GetAllInstances(offset, limit)` which does not take a userID at all.
- `GetVisibleInstances` is removed; nothing else called it.

**Frontend**

- New `adminInstanceService.getInstances()` hits `/admin/instances`.
- `AdminDashboard` and `InstanceManagementPage` switch to it.
- The regular `instanceService` is unchanged; the rest of the app continues to use it for workspace views and per-instance actions.

**Out of scope**

Per-instance handlers (`GetInstance`, `StartInstance`, `StopInstance`, `DeleteInstance`, proxy, etc.) keep their existing inline `userRole != "admin" && instance.UserID != userID` checks. Those endpoints are correctly scoped today; auditing them for the same "role overloaded as authorization" smell belongs in a separate, reviewable PR.

## Tests

Two new unit tests in `backend/internal/services/instance_visibility_test.go`:

- `TestGetByUserIDFiltersByCaller` — regression guard. Seeds instances for two users plus a third user with none, verifies every caller sees only their own rows, and that a user with no instances gets an empty list rather than someone else's data.
- `TestGetAllInstancesReturnsEveryUser` — covers the admin-console path, including pagination boundaries.


## Impact on existing clients

- Non-admin workspace behavior: unchanged.
- Admin workspace behavior: now correctly scoped to own instances. If an existing admin UI was relying on `GET /instances` as a cross-user listing, it should migrate to `GET /admin/instances`. The two admin pages in this repo have already been migrated.
- Wire format of both endpoints is identical (`{ instances, total, page, limit }`), so the new admin endpoint is a drop-in for callers that used to expect cross-user data from `/instances`.
