### PR TITLE
fix: add graceful shutdown, fix WebSocket Hub race, plug goroutine leaks

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"context"
 	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"clawreef/internal/aigateway"
 	"clawreef/internal/config"
@@ -123,7 +129,6 @@ func main() {
 	// Start sync service to keep instance status in sync with K8s
 	syncService := services.NewSyncService(instanceRepo, instanceRuntimeStatusService)
 	syncService.Start()
-	defer syncService.Stop()
 
 	// Setup router
 	r := gin.Default()
@@ -351,9 +356,37 @@ func main() {
 		}
 	}
 
-	// Start server
-	log.Printf("Server starting on %s", cfg.Server.Address)
-	if err := r.Run(cfg.Server.Address); err != nil {
-		log.Fatalf("Failed to start server: %v", err)
+	// Start server with graceful shutdown
+	srv := &http.Server{
+		Addr:    cfg.Server.Address,
+		Handler: r,
 	}
+
+	go func() {
+		log.Printf("Server starting on %s", cfg.Server.Address)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Failed to start server: %v", err)
+		}
+	}()
+
+	// Wait for interrupt signal
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-quit
+	log.Printf("Received signal %v, shutting down gracefully...", sig)
+
+	// Give active requests up to 10 seconds to finish
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Printf("HTTP server forced to shutdown: %v", err)
+	}
+
+	// Stop background services
+	syncService.Stop()
+	wsHub.Stop()
+	instanceHandler.Shutdown()
+
+	log.Println("Server exited cleanly")
 }

--- a/backend/internal/handlers/instance_handler.go
+++ b/backend/internal/handlers/instance_handler.go
@@ -46,6 +46,13 @@ func NewInstanceHandler(instanceService services.InstanceService, instanceAgentS
 	}
 }
 
+// Shutdown releases resources held by the handler (e.g. background goroutines).
+func (h *InstanceHandler) Shutdown() {
+	if h.accessService != nil {
+		h.accessService.Stop()
+	}
+}
+
 type InstanceRuntimeDetailsResponse struct {
 	Runtime  *services.InstanceRuntimeStatusPayload `json:"runtime,omitempty"`
 	Agent    *services.InstanceAgentPayload         `json:"agent,omitempty"`

--- a/backend/internal/services/instance_access_service.go
+++ b/backend/internal/services/instance_access_service.go
@@ -24,9 +24,10 @@ type AccessToken struct {
 
 // InstanceAccessService manages instance access tokens
 type InstanceAccessService struct {
-	tokens map[string]*AccessToken
-	mu     sync.RWMutex
-	secret string
+	tokens   map[string]*AccessToken
+	mu       sync.RWMutex
+	secret   string
+	stopChan chan struct{}
 }
 
 type instanceAccessClaims struct {
@@ -42,8 +43,9 @@ type instanceAccessClaims struct {
 // NewInstanceAccessService creates a new instance access service
 func NewInstanceAccessService() *InstanceAccessService {
 	service := &InstanceAccessService{
-		tokens: make(map[string]*AccessToken),
-		secret: getInstanceAccessTokenSecret(),
+		tokens:   make(map[string]*AccessToken),
+		secret:   getInstanceAccessTokenSecret(),
+		stopChan: make(chan struct{}),
 	}
 
 	// Start cleanup goroutine
@@ -234,16 +236,26 @@ func (s *InstanceAccessService) cleanupExpiredTokens() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		now := time.Now()
-		s.mu.Lock()
-		for token, accessToken := range s.tokens {
-			if now.After(accessToken.ExpiresAt) {
-				delete(s.tokens, token)
+	for {
+		select {
+		case <-s.stopChan:
+			return
+		case <-ticker.C:
+			now := time.Now()
+			s.mu.Lock()
+			for token, accessToken := range s.tokens {
+				if now.After(accessToken.ExpiresAt) {
+					delete(s.tokens, token)
+				}
 			}
+			s.mu.Unlock()
 		}
-		s.mu.Unlock()
 	}
+}
+
+// Stop terminates the background cleanup goroutine.
+func (s *InstanceAccessService) Stop() {
+	close(s.stopChan)
 }
 
 // GetActiveTokenCount returns the number of active tokens

--- a/backend/internal/services/instance_access_service_test.go
+++ b/backend/internal/services/instance_access_service_test.go
@@ -70,3 +70,22 @@ func TestInstanceAccessServiceFallsBackToLegacyTokens(t *testing.T) {
 		t.Fatalf("validated.InstanceID = %d, want 11", validated.InstanceID)
 	}
 }
+
+func TestInstanceAccessServiceStopTerminatesCleanup(t *testing.T) {
+	t.Setenv("INSTANCE_ACCESS_TOKEN_SECRET", "cluster-shared-secret")
+
+	service := NewInstanceAccessService()
+
+	// Stop should not panic and should be idempotent-safe (only called once).
+	service.Stop()
+
+	// After Stop, the service should still be usable for token operations
+	// (only the background cleanup goroutine is stopped).
+	token, err := service.GenerateToken(1, 1, "openclaw", "/proxy", 3001, time.Minute)
+	if err != nil {
+		t.Fatalf("GenerateToken after Stop() error = %v", err)
+	}
+	if _, err := service.ValidateToken(token.Token); err != nil {
+		t.Fatalf("ValidateToken after Stop() error = %v", err)
+	}
+}

--- a/backend/internal/services/websocket_service.go
+++ b/backend/internal/services/websocket_service.go
@@ -36,6 +36,7 @@ type Hub struct {
 	register   chan *Client
 	unregister chan *Client
 	mu         sync.RWMutex
+	stop       chan struct{}
 }
 
 // Message represents a WebSocket message
@@ -56,14 +57,17 @@ type InstanceStatusUpdate struct {
 	UpdatedAt  string `json:"updated_at"`
 }
 
-var hub *Hub
+var (
+	hub     *Hub
+	hubOnce sync.Once
+)
 
 // GetHub returns the global hub instance
 func GetHub() *Hub {
-	if hub == nil {
+	hubOnce.Do(func() {
 		hub = NewHub()
 		go hub.Run()
-	}
+	})
 	return hub
 }
 
@@ -74,6 +78,7 @@ func NewHub() *Hub {
 		broadcast:  make(chan *Message),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
+		stop:       make(chan struct{}),
 	}
 }
 
@@ -81,6 +86,16 @@ func NewHub() *Hub {
 func (h *Hub) Run() {
 	for {
 		select {
+		case <-h.stop:
+			h.mu.Lock()
+			for client := range h.clients {
+				close(client.Send)
+				delete(h.clients, client)
+			}
+			h.mu.Unlock()
+			log.Println("WebSocket hub stopped")
+			return
+
 		case client := <-h.register:
 			h.mu.Lock()
 			h.clients[client] = true
@@ -261,4 +276,10 @@ func (h *Hub) GetClientCount() int {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return len(h.clients)
+}
+
+
+// Stop gracefully shuts down the hub, closing all client connections.
+func (h *Hub) Stop() {
+	close(h.stop)
 }

--- a/backend/internal/services/websocket_service_test.go
+++ b/backend/internal/services/websocket_service_test.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGetHubReturnsSameInstance(t *testing.T) {
+	// Reset the package-level singleton so the test is self-contained.
+	hubOnce = sync.Once{}
+	hub = nil
+
+	h1 := GetHub()
+	h2 := GetHub()
+	if h1 != h2 {
+		t.Fatal("GetHub() returned different instances")
+	}
+
+	// Cleanup: stop the hub so the goroutine doesn't leak.
+	h1.Stop()
+}
+
+func TestGetHubConcurrentAccess(t *testing.T) {
+	hubOnce = sync.Once{}
+	hub = nil
+
+	const goroutines = 50
+	results := make(chan *Hub, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			results <- GetHub()
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var first *Hub
+	for h := range results {
+		if first == nil {
+			first = h
+		} else if h != first {
+			t.Fatal("GetHub() returned different instances under concurrent access")
+		}
+	}
+
+	first.Stop()
+}
+
+func TestHubStopClosesClients(t *testing.T) {
+	h := NewHub()
+	go h.Run()
+
+	// Register a fake client with a buffered Send channel.
+	client := &Client{
+		UserID: 1,
+		Send:   make(chan []byte, 8),
+		hub:    h,
+	}
+	h.register <- client
+
+	// Give the hub a moment to process the registration.
+	time.Sleep(20 * time.Millisecond)
+
+	if h.GetClientCount() != 1 {
+		t.Fatalf("expected 1 client, got %d", h.GetClientCount())
+	}
+
+	h.Stop()
+
+	// Give the hub a moment to process the stop.
+	time.Sleep(20 * time.Millisecond)
+
+	if h.GetClientCount() != 0 {
+		t.Fatalf("expected 0 clients after Stop, got %d", h.GetClientCount())
+	}
+
+	// The client's Send channel should be closed.
+	_, ok := <-client.Send
+	if ok {
+		t.Fatal("expected client.Send to be closed after hub Stop")
+	}
+}
+


### PR DESCRIPTION
## Summary

Address three HIGH-severity issues identified in the memory-leak and bloat analysis (ref #56). These are production-safety fixes that improve process lifecycle management without changing any user-facing behavior.

## Changes

### 1. Graceful Shutdown (`main.go`)

**Problem**: The server uses `gin.Engine.Run()` which blocks until the process is killed. On SIGINT/SIGTERM (e.g. during deploy), active HTTP requests are dropped, database connections leak, and background goroutines are orphaned.

**Fix**: Replace `r.Run()` with an explicit `http.Server` + signal handler:
- Intercept SIGINT and SIGTERM
- Drain active requests with a 10-second timeout via `srv.Shutdown(ctx)`
- Stop background services in order: SyncService → WebSocket Hub → InstanceAccessService cleanup

### 2. WebSocket Hub Init Race (`websocket_service.go`)

**Problem**: `GetHub()` uses a bare `if hub == nil` check with no synchronization. Under concurrent access (e.g. multiple WebSocket connections arriving simultaneously at startup), two goroutines can each create a Hub and start a `Run()` loop — resulting in a leaked goroutine and split client state.

**Fix**:
- Replace the nil-check with `sync.Once` to guarantee exactly one Hub instance
- Add a `stop` channel to `Hub.Run()` so the hub can be shut down gracefully, closing all connected clients and their Send channels

### 3. InstanceAccessService Goroutine Leak (`instance_access_service.go`)

**Problem**: `cleanupExpiredTokens()` loops on `ticker.C` with no exit path. The goroutine runs for the entire lifetime of the process and cannot be stopped — a textbook goroutine leak.

**Fix**:
- Add a `stopChan` to the service struct
- `cleanupExpiredTokens()` now selects on both the ticker and the stop signal
- Expose `Stop()` on the service
- Add `InstanceHandler.Shutdown()` that calls `accessService.Stop()` during graceful shutdown

## Testing

4 new tests added:

| Test | What it verifies |
|------|-----------------|
| `TestGetHubReturnsSameInstance` | Singleton guarantee — GetHub() always returns the same pointer |
| `TestGetHubConcurrentAccess` | 50-goroutine race test — no duplicate Hub creation |
| `TestHubStopClosesClients` | Stop() closes all client Send channels and clears the client map |
| `TestInstanceAccessServiceStopTerminatesCleanup` | Stop() is safe; service remains functional for token operations afterward |

All existing tests continue to pass. Full project build and regression verified.

## Impact

- **Zero behavioral change** for end users — these are purely internal lifecycle fixes
- **Safer deploys** — active requests drain cleanly instead of being killed
- **No leaked goroutines** — all background loops now have explicit stop mechanisms
- **No new dependencies** — uses only stdlib (`sync.Once`, `os/signal`, `context`)

Ref: #56