### PR TITLE
fix: default imagePullPolicy to IfNotPresent for air-gapped environments

### DIFF
--- a/backend/internal/services/instance_runtime.go
+++ b/backend/internal/services/instance_runtime.go
@@ -142,6 +142,17 @@ func usesWebtopImage(instanceType string) bool {
 	}
 }
 
+// defaultImagePullPolicy returns the image pull policy to use for instance
+// pods. Operators can override the default ("IfNotPresent") by setting the
+// IMAGE_PULL_POLICY environment variable to "Always", "Never", or
+// "IfNotPresent".
+func defaultImagePullPolicy() string {
+	if v := strings.TrimSpace(os.Getenv("IMAGE_PULL_POLICY")); v != "" {
+		return v
+	}
+	return "IfNotPresent"
+}
+
 func defaultEgressProxyURL() (string, bool) {
 	if override := strings.TrimSpace(os.Getenv("CLAWMANAGER_EGRESS_PROXY_URL")); override != "" {
 		return override, true

--- a/backend/internal/services/instance_runtime_test.go
+++ b/backend/internal/services/instance_runtime_test.go
@@ -1,0 +1,42 @@
+package services
+
+import "testing"
+
+func TestDefaultImagePullPolicy_Default(t *testing.T) {
+	// With no env var set, should return "IfNotPresent".
+	t.Setenv("IMAGE_PULL_POLICY", "")
+	got := defaultImagePullPolicy()
+	if got != "IfNotPresent" {
+		t.Fatalf("expected IfNotPresent, got %q", got)
+	}
+}
+
+func TestDefaultImagePullPolicy_EnvOverride(t *testing.T) {
+	cases := []struct {
+		env  string
+		want string
+	}{
+		{"Always", "Always"},
+		{"Never", "Never"},
+		{"IfNotPresent", "IfNotPresent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv("IMAGE_PULL_POLICY", tc.env)
+			got := defaultImagePullPolicy()
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestDefaultImagePullPolicy_WhitespaceOnly(t *testing.T) {
+	// Whitespace-only env var should fall back to default.
+	t.Setenv("IMAGE_PULL_POLICY", "   ")
+	got := defaultImagePullPolicy()
+	if got != "IfNotPresent" {
+		t.Fatalf("expected IfNotPresent, got %q", got)
+	}
+}
+

--- a/backend/internal/services/instance_service.go
+++ b/backend/internal/services/instance_service.go
@@ -14,6 +14,7 @@ import (
 	"clawreef/internal/repository"
 	"clawreef/internal/services/k8s"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -313,6 +314,7 @@ func (s *instanceService) Create(userID int, req CreateInstanceRequest) (*models
 		Image:              runtimeConfig.Image,
 		MountPath:          runtimeConfig.MountPath,
 		ContainerPort:      runtimeConfig.Port,
+		ImagePullPolicy:    corev1.PullPolicy(defaultImagePullPolicy()),
 		ExtraEnv:           extraEnv,
 		EnvFromSecretNames: []string{bootstrapSecretName},
 	}
@@ -488,6 +490,7 @@ func (s *instanceService) Start(instanceID int) error {
 		Image:              runtimeConfig.Image,
 		MountPath:          instance.MountPath,
 		ContainerPort:      runtimeConfig.Port,
+		ImagePullPolicy:    corev1.PullPolicy(defaultImagePullPolicy()),
 		ExtraEnv:           extraEnv,
 		EnvFromSecretNames: []string{bootstrapSecretName},
 	}

--- a/backend/internal/services/k8s/pod_service.go
+++ b/backend/internal/services/k8s/pod_service.go
@@ -47,6 +47,7 @@ type PodConfig struct {
 	Image              string
 	MountPath          string
 	ContainerPort      int32
+	ImagePullPolicy    corev1.PullPolicy
 	ExtraEnv           map[string]string
 	EnvFromSecretNames []string
 }
@@ -84,6 +85,14 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 		config.ContainerPort = 3001
 	}
 
+	// Default image pull policy to IfNotPresent so that air-gapped and
+	// enterprise environments can use locally cached images without being
+	// forced to pull from a remote registry (fixes #94).
+	pullPolicy := config.ImagePullPolicy
+	if pullPolicy == "" {
+		pullPolicy = corev1.PullIfNotPresent
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -101,8 +110,9 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
 				{
-					Name:  "desktop",
-					Image: config.Image,
+					Name:            "desktop",
+					Image:           config.Image,
+					ImagePullPolicy: pullPolicy,
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: config.ContainerPort,


### PR DESCRIPTION
## Summary

Fixes #94 — Pods fail to start in air-gapped / enterprise environments because Kubernetes defaults `imagePullPolicy` to `Always` for images tagged `:latest`.

## Root Cause

`defaultSystemImageSettings["openclaw"]` resolves to `ghcr.io/yuan-lab-llm/clawmanager-openclaw-image/openclaw:latest`. When no explicit `imagePullPolicy` is set on the container spec, Kubernetes applies its default rule: **`:latest` tag → `Always`**. Nodes in air-gapped networks cannot reach `ghcr.io`, so the pod stays in `ImagePullBackOff`.

## Changes

| File | Change |
|------|--------|
| `pod_service.go` | Add `ImagePullPolicy` field to `PodConfig`; default to `IfNotPresent` in `CreatePod` |
| `instance_runtime.go` | Add `defaultImagePullPolicy()` — reads `IMAGE_PULL_POLICY` env var, falls back to `IfNotPresent` |
| `instance_service.go` | Pass `ImagePullPolicy` in both `CreateInstance` and `StartInstance` pod config paths |
| `instance_runtime_test.go` | 5 new tests: default value, env var override (Always/Never/IfNotPresent), whitespace fallback |

## Operator Configuration

Set the `IMAGE_PULL_POLICY` environment variable on the backend deployment to override the default:



## Impact

- **Air-gapped environments**: pods now start successfully using locally cached images.
- **Connected environments**: behavior unchanged for non-`:latest` tags (K8s already defaults to `IfNotPresent`). For `:latest` tags, operators can set `IMAGE_PULL_POLICY=Always` to restore the previous behavior.
- **Zero breaking changes**: `ImagePullPolicy` is an additive struct field; callers that omit it get the safe default.

## Testing

- All existing tests pass (zero regression)
- 5 new unit tests for `defaultImagePullPolicy()`
- Full build verified
