### PR TITLE
fix: make instance deletion asynchronous

### DIFF
--- a/backend/internal/handlers/instance_handler.go
+++ b/backend/internal/handlers/instance_handler.go
@@ -342,7 +342,7 @@ func (h *InstanceHandler) DeleteInstance(c *gin.Context) {
 		return
 	}
 
-	utils.Success(c, http.StatusOK, "Instance deleted successfully", nil)
+	utils.Success(c, http.StatusAccepted, "Instance deletion started", nil)
 }
 
 // StartInstance starts an instance

--- a/backend/internal/services/instance_service.go
+++ b/backend/internal/services/instance_service.go
@@ -766,40 +766,53 @@ func (s *instanceService) Restart(instanceID int) error {
 	return nil
 }
 
-// Delete deletes an instance and all associated K8s resources
+// Delete starts deleting an instance and all associated K8s resources.
 func (s *instanceService) Delete(instanceID int) error {
-	ctx := context.Background()
-
 	instance, err := s.instanceRepo.GetByID(instanceID)
 	if err != nil {
 		return fmt.Errorf("failed to get instance: %w", err)
 	}
 
 	if instance == nil {
-		// Instance not in DB, but we should still try to clean up K8s resources
-		fmt.Printf("Instance %d not found in database, attempting to clean up any orphaned K8s resources\n", instanceID)
-		// Try to clean up with userID=0 (will need to scan all namespaces)
-		cleanupService := k8s.NewCleanupService()
-		cleanupService.DeleteAllInstanceResources(ctx, 0, instanceID)
 		return fmt.Errorf("instance not found")
 	}
 
-	fmt.Printf("Starting deletion of instance %d (user %d)\n", instanceID, instance.UserID)
+	if instance.Status != "deleting" {
+		now := time.Now()
+		instance.Status = "deleting"
+		instance.UpdatedAt = now
+
+		if err := s.instanceRepo.Update(instance); err != nil {
+			return fmt.Errorf("failed to mark instance as deleting: %w", err)
+		}
+
+		GetHub().BroadcastInstanceStatus(instance.UserID, instance)
+	}
+
+	go s.completeDeletion(instance.UserID, instance.ID)
+
+	return nil
+}
+
+func (s *instanceService) completeDeletion(userID, instanceID int) {
+	ctx := context.Background()
+
+	fmt.Printf("Starting background deletion of instance %d (user %d)\n", instanceID, userID)
 
 	// Use CleanupService to delete ALL resources for this instance (including duplicates)
 	cleanupService := k8s.NewCleanupService()
-	if err := cleanupService.DeleteAllInstanceResources(ctx, instance.UserID, instance.ID); err != nil {
+	if err := cleanupService.DeleteAllInstanceResources(ctx, userID, instanceID); err != nil {
 		fmt.Printf("Warning: error during resource cleanup for instance %d: %v\n", instanceID, err)
 	}
 
-	// 4. Delete instance record from database
+	// Delete instance record from database after background cleanup finishes.
 	fmt.Printf("Deleting instance %d from database...\n", instanceID)
 	if err := s.instanceRepo.Delete(instanceID); err != nil {
-		return fmt.Errorf("failed to delete instance record: %w", err)
+		fmt.Printf("Error: failed to delete instance %d record: %v\n", instanceID, err)
+		return
 	}
 
 	fmt.Printf("Instance %d deleted successfully\n", instanceID)
-	return nil
 }
 
 // cleanupOrphanedResources cleans up any orphaned K8s resources for an instance

--- a/frontend/src/pages/admin/InstanceManagementPage.tsx
+++ b/frontend/src/pages/admin/InstanceManagementPage.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useEffect, useMemo, useState } from 'react';
+﻿import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import AdminLayout from '../../components/AdminLayout';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { useI18n } from '../../contexts/I18nContext';
@@ -20,13 +20,11 @@ const InstanceManagementPage: React.FC = () => {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [pendingDeleteInstance, setPendingDeleteInstance] = useState<Instance | null>(null);
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  const loadData = async () => {
+  const loadData = useCallback(async (options?: { silent?: boolean }) => {
     try {
-      setLoading(true);
+      if (!options?.silent) {
+        setLoading(true);
+      }
       setError(null);
       const [instancesData, usersData] = await Promise.all([
         adminInstanceService.getInstances(1, 1000),
@@ -37,9 +35,29 @@ const InstanceManagementPage: React.FC = () => {
     } catch (err: any) {
       setError(err.response?.data?.error || t('admin.failedToLoadInstances'));
     } finally {
-      setLoading(false);
+      if (!options?.silent) {
+        setLoading(false);
+      }
     }
-  };
+  }, [t]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    if (!instances.some((instance) => instance.status === 'creating' || instance.status === 'deleting')) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void loadData({ silent: true });
+    }, 5000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [instances, loadData]);
 
   const userMap = useMemo(() => {
     return new Map(users.map((user) => [user.id, user.username]));
@@ -196,7 +214,7 @@ const InstanceManagementPage: React.FC = () => {
               ))}
             </select>
             <button
-              onClick={loadData}
+              onClick={() => void loadData()}
               className="app-button-secondary"
             >
               {t('common.refresh')}
@@ -299,14 +317,14 @@ const InstanceManagementPage: React.FC = () => {
                           )}
                           <button
                             onClick={() => handleAction(instance, 'sync')}
-                            disabled={actionLoading === `sync-${instance.id}`}
+                            disabled={actionLoading === `sync-${instance.id}` || instance.status === 'deleting'}
                             className="rounded-md bg-[#f3f0ed] px-3 py-1.5 text-xs font-medium text-[#5f5957] hover:bg-[#ebe3dd] disabled:opacity-50"
                           >
                             {t('common.refresh')}
                           </button>
                           <button
                             onClick={() => setPendingDeleteInstance(instance)}
-                            disabled={actionLoading === `delete-${instance.id}`}
+                            disabled={actionLoading === `delete-${instance.id}` || instance.status === 'deleting'}
                             className="rounded-md bg-red-50 px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-100 disabled:opacity-50"
                           >
                             {t('common.delete')}

--- a/frontend/src/pages/instances/InstanceListPage.tsx
+++ b/frontend/src/pages/instances/InstanceListPage.tsx
@@ -8,7 +8,7 @@ import type { Instance } from '../../types/instance';
 import { useI18n } from '../../contexts/I18nContext';
 
 type ViewMode = 'list' | 'card';
-type StatusFilter = 'all' | 'running' | 'stopped' | 'creating' | 'error';
+type StatusFilter = 'all' | 'running' | 'stopped' | 'creating' | 'deleting' | 'error';
 
 const INSTANCE_FIELDS_TO_COMPARE: Array<keyof Instance> = [
   'id',
@@ -149,7 +149,7 @@ const InstanceCardItem = React.memo(({
         </Link>
         <button
           onClick={() => onRequestDelete(instance.id)}
-          disabled={deletingIds.includes(instance.id)}
+          disabled={deletingIds.includes(instance.id) || instance.status === 'deleting'}
           className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded text-red-700 bg-red-100 hover:bg-red-200 focus:outline-none disabled:opacity-50"
         >
           {deletingIds.includes(instance.id) ? `${t('common.delete')}...` : t('common.delete')}
@@ -223,7 +223,7 @@ const InstanceListItem = React.memo(({
 
         <button
           onClick={() => onRequestDelete(instance.id)}
-          disabled={deletingIds.includes(instance.id)}
+          disabled={deletingIds.includes(instance.id) || instance.status === 'deleting'}
           className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded text-red-700 bg-red-100 hover:bg-red-200 focus:outline-none disabled:opacity-50"
         >
           {deletingIds.includes(instance.id) ? `${t('common.delete')}...` : t('common.delete')}
@@ -269,7 +269,7 @@ const InstanceListPage: React.FC = () => {
   }, [loadInstances]);
 
   useEffect(() => {
-    if (!instances.some((instance) => instance.status === 'creating')) {
+    if (!instances.some((instance) => instance.status === 'creating' || instance.status === 'deleting')) {
       return;
     }
 
@@ -280,7 +280,7 @@ const InstanceListPage: React.FC = () => {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [instances]);
+  }, [instances, loadInstances]);
 
   // Handle WebSocket status updates
   const handleStatusUpdate = useCallback((update: { instance_id: number; status: string; pod_name?: string; pod_ip?: string }) => {
@@ -330,14 +330,19 @@ const InstanceListPage: React.FC = () => {
     try {
       setDeletingIds((prevIds) => [...prevIds, id]);
       await instanceService.deleteInstance(id);
-      setInstances((prevInstances) => prevInstances.filter((instance) => instance.id !== id));
+      setInstances((prevInstances) =>
+        prevInstances.map((instance) =>
+          instance.id === id ? { ...instance, status: 'deleting' } : instance,
+        ),
+      );
       setPendingDeleteId(null);
+      await loadInstances({ silent: true });
     } catch (err: any) {
       alert(err.response?.data?.error || t('instances.failedToDelete'));
     } finally {
       setDeletingIds((prevIds) => prevIds.filter((deletingId) => deletingId !== id));
     }
-  }, [t]);
+  }, [loadInstances, t]);
 
   const handleStart = useCallback(async (id: number) => {
     try {
@@ -375,10 +380,12 @@ const InstanceListPage: React.FC = () => {
         return 'bg-gray-100 text-gray-800';
       case 'creating':
         return 'bg-yellow-100 text-yellow-800';
+      case 'deleting':
+        return 'bg-orange-100 text-orange-800';
       case 'error':
         return 'bg-red-100 text-red-800';
       default:
-        return 'VM';
+        return 'bg-gray-100 text-gray-800';
     }
   };
 
@@ -399,6 +406,13 @@ const InstanceListPage: React.FC = () => {
       case 'creating':
         return (
           <svg className="animate-spin w-3 h-3 mr-1.5 text-yellow-600" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
+        );
+      case 'deleting':
+        return (
+          <svg className="animate-spin w-3 h-3 mr-1.5 text-orange-600" fill="none" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
           </svg>
@@ -555,6 +569,7 @@ const InstanceListPage: React.FC = () => {
             <option value="running">{t('status.running')}</option>
             <option value="stopped">{t('status.stopped')}</option>
             <option value="creating">{t('status.creating')}</option>
+            <option value="deleting">{t('status.deleting')}</option>
             <option value="error">{t('status.error')}</option>
           </select>
 


### PR DESCRIPTION
## Summary
This PR makes instance deletion asynchronous.

* Marks an instance as deleting immediately when deletion is requested
* Returns 202 Accepted without waiting for Kubernetes pods/resources to disappear
* Runs Kubernetes cleanup and final database record deletion in the background
* Keeps the instance visible as deleting in user/admin lists until cleanup completes