### PR TITLE
fix: mount PVC to /home/node/.openclaw for openclaw instances

### DIFF
--- a/backend/internal/db/migrations/014_openclaw_persistent_mount_path.sql
+++ b/backend/internal/db/migrations/014_openclaw_persistent_mount_path.sql
@@ -1,0 +1,7 @@
+-- OpenClaw instances: change PVC mount from /config to /home/node/.openclaw
+-- so that the workspace (memory, config, plugins) survives pod restarts.
+UPDATE instances
+SET mount_path = '/home/node/.openclaw'
+WHERE type = 'openclaw'
+  AND mount_path IN ('/config', '/home/user/data');
+

--- a/backend/internal/services/instance_runtime.go
+++ b/backend/internal/services/instance_runtime.go
@@ -68,7 +68,7 @@ func buildRuntimeConfig(instanceType, osType, osVersion string, registry, tag *s
 			"SUBFOLDER": "/",
 		}
 	case "openclaw":
-		config.MountPath = "/config"
+		config.MountPath = "/home/node/.openclaw"
 		if (registry == nil || strings.TrimSpace(*registry) == "") && (tag == nil || strings.TrimSpace(*tag) == "") {
 			config.Image = defaultSystemImageSettings["openclaw"]
 		} else {
@@ -99,10 +99,12 @@ func defaultPortForInstanceType(instanceType string) int32 {
 
 func defaultMountPathForInstanceType(instanceType string) string {
 	switch instanceType {
-	case "ubuntu", "webtop", "openclaw":
+	case "ubuntu", "webtop":
 		return "/config"
 	case "hermes":
 		return "/config/.hermes"
+	case "openclaw":
+		return "/home/node/.openclaw"
 	default:
 		return "/home/user/data"
 	}


### PR DESCRIPTION
OpenClaw stores workspace data (SOUL.md, USER.md, HEARTBEAT.md, memory/*.md) under /home/node/.openclaw/workspace/, but the PVC was mounted at /config (unused by OpenClaw). This caused all workspace data to live on ephemeral storage, meaning any pod restart wiped the agent's memory completely.

Changes:
- buildRuntimeConfig(): set openclaw MountPath to /home/node/.openclaw
- defaultMountPathForInstanceType(): return /home/node/.openclaw for openclaw
- Migration 014: update existing openclaw instances in DB

After this fix, pod restarts will preserve workspace files on the PVC.

Closes #49