### PR TITLE
feat: add node_name field and NodeSelector for pod scheduling

### DIFF
--- a/backend/internal/db/migrations/015_add_instance_node_name.sql
+++ b/backend/internal/db/migrations/015_add_instance_node_name.sql
@@ -1,0 +1,5 @@
+-- Migration 015: Add node_name column to instances table
+-- This allows pods to be pinned to a specific worker node via NodeSelector,
+-- ensuring hostPath PVC data is always accessible after pod restarts.
+ALTER TABLE instances ADD COLUMN node_name VARCHAR(255) DEFAULT NULL AFTER pod_ip;
+

--- a/backend/internal/models/instance.go
+++ b/backend/internal/models/instance.go
@@ -28,6 +28,7 @@ type Instance struct {
 	PodName                  *string    `db:"pod_name" json:"pod_name,omitempty"`
 	PodNamespace             *string    `db:"pod_namespace" json:"pod_namespace,omitempty"`
 	PodIP                    *string    `db:"pod_ip" json:"pod_ip,omitempty"`
+	NodeName                 *string    `db:"node_name" json:"node_name,omitempty"`
 	AccessURL                *string    `db:"access_url" json:"access_url,omitempty"`
 	AccessToken              *string    `db:"access_token" json:"-"`
 	AgentBootstrapToken      *string    `db:"agent_bootstrap_token" json:"-"`

--- a/backend/internal/services/instance_service.go
+++ b/backend/internal/services/instance_service.go
@@ -50,6 +50,7 @@ type CreateInstanceRequest struct {
 	EnvironmentOverrides map[string]string   `json:"environment_overrides,omitempty"`
 	StorageClass         string              `json:"storage_class"`
 	OpenClawConfigPlan   *OpenClawConfigPlan `json:"openclaw_config_plan,omitempty"`
+	NodeName             *string             `json:"node_name,omitempty"`
 }
 
 // UpdateInstanceRequest holds data for updating an instance
@@ -217,6 +218,7 @@ func (s *instanceService) Create(userID int, req CreateInstanceRequest) (*models
 		EnvironmentOverridesJSON: environmentOverridesJSON,
 		StorageClass:             req.StorageClass,
 		MountPath:                runtimeConfig.MountPath,
+		NodeName:                 req.NodeName,
 		CreatedAt:                now,
 		UpdatedAt:                now,
 	}
@@ -317,6 +319,7 @@ func (s *instanceService) Create(userID int, req CreateInstanceRequest) (*models
 		ImagePullPolicy:    corev1.PullPolicy(defaultImagePullPolicy()),
 		ExtraEnv:           extraEnv,
 		EnvFromSecretNames: []string{bootstrapSecretName},
+		NodeName:           derefString(instance.NodeName),
 	}
 
 	pod, err := s.podService.CreatePod(ctx, podConfig)
@@ -485,6 +488,7 @@ func (s *instanceService) Start(instanceID int) error {
 		ImagePullPolicy:    corev1.PullPolicy(defaultImagePullPolicy()),
 		ExtraEnv:           extraEnv,
 		EnvFromSecretNames: []string{bootstrapSecretName},
+		NodeName:           derefString(instance.NodeName),
 	}
 
 	pod, err := s.podService.CreatePod(ctx, podConfig)
@@ -1143,4 +1147,12 @@ func additionalServicePorts(primaryPort int32) []int32 {
 	}
 
 	return nil
+}
+
+// derefString safely dereferences a *string, returning "" if nil.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/backend/internal/services/k8s/pod_service.go
+++ b/backend/internal/services/k8s/pod_service.go
@@ -50,6 +50,7 @@ type PodConfig struct {
 	ImagePullPolicy    corev1.PullPolicy
 	ExtraEnv           map[string]string
 	EnvFromSecretNames []string
+	NodeName           string // If set, pod is pinned to this node via NodeSelector
 }
 
 // CreatePod creates a new pod for an instance
@@ -108,6 +109,7 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
+			NodeSelector:  buildNodeSelector(config.NodeName),
 			Containers: []corev1.Container{
 				{
 					Name:            "desktop",
@@ -235,6 +237,17 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 
 func intstrFromInt32(port int32) intstr.IntOrString {
 	return intstr.FromInt32(port)
+}
+
+// buildNodeSelector returns a NodeSelector map that pins the pod to the given
+// node. If nodeName is empty, returns nil (no scheduling constraint).
+func buildNodeSelector(nodeName string) map[string]string {
+	if nodeName == "" {
+		return nil
+	}
+	return map[string]string{
+		"kubernetes.io/hostname": nodeName,
+	}
 }
 
 // GetPod gets a pod by instance ID


### PR DESCRIPTION
PVC uses hostPath, so pod data lives on a specific worker node. Without scheduling constraints, a restarted pod could land on a different node and lose access to its persistent data.

Changes:
- Migration 015: add node_name column to instances table
- Model: add NodeName field to Instance struct
- PodConfig: add NodeName field
- CreatePod(): set pod.Spec.NodeSelector when NodeName is provided, using kubernetes.io/hostname label (still goes through scheduler)
- CreateInstanceRequest: accept optional node_name in API
- Create()/Start(): pass NodeName from instance to PodConfig

When node_name is NULL (existing instances), no scheduling constraint is applied — fully backward compatible. The taint/untaint workaround is no longer needed for new instances that specify node_name.