### PR TITLE
fix: use persistent path for PV hostPath instead of /tmp/

### DIFF
--- a/backend/configs/k8s.yaml
+++ b/backend/configs/k8s.yaml
@@ -114,6 +114,11 @@ runtime:
     # 保留策略: Retain | Delete | Recycle
     reclaimPolicy: "Delete"
 
+    # HostPath 前缀（用于手动创建 PV 时的主机路径）
+    # 注意：不要使用 /tmp/ 等临时目录，节点重启可能导致数据丢失
+    # 环境变量覆盖: K8S_PV_HOST_PATH_PREFIX
+    hostPathPrefix: "/data/clawreef"
+
 # 日志配置
 logging:
   # 日志级别: debug | info | warn | error

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -113,6 +113,7 @@ type RuntimePVCConfig struct {
 	VolumeMode           string `yaml:"volumeMode"`
 	AllowVolumeExpansion bool   `yaml:"allowVolumeExpansion"`
 	ReclaimPolicy        string `yaml:"reclaimPolicy"`
+	HostPathPrefix       string `yaml:"hostPathPrefix"`
 }
 
 // LoggingConfig holds logging configuration
@@ -190,6 +191,7 @@ func Load() (*Config, error) {
 					VolumeMode:           "Filesystem",
 					AllowVolumeExpansion: true,
 					ReclaimPolicy:        "Delete",
+					HostPathPrefix:       getEnv("K8S_PV_HOST_PATH_PREFIX", "/data/clawreef"),
 				},
 			},
 			Logging: LoggingConfig{
@@ -302,6 +304,9 @@ func applyEnvOverrides(config *Config) {
 	if storageClass := os.Getenv("K8S_STORAGE_CLASS"); storageClass != "" {
 		config.Kubernetes.Common.StorageClass = storageClass
 	}
+	if hostPathPrefix := os.Getenv("K8S_PV_HOST_PATH_PREFIX"); hostPathPrefix != "" {
+		config.Kubernetes.Runtime.PVC.HostPathPrefix = hostPathPrefix
+	}
 
 	if endpoint := os.Getenv("OBJECT_STORAGE_ENDPOINT"); endpoint != "" {
 		config.ObjectStorage.Endpoint = endpoint
@@ -364,6 +369,14 @@ func (c *Config) GetNamespace() string {
 // GetStorageClass returns the storage class
 func (c *Config) GetStorageClass() string {
 	return c.Kubernetes.Common.StorageClass
+}
+
+// GetHostPathPrefix returns the host path prefix for PV creation
+func (c *Config) GetHostPathPrefix() string {
+	if c.Kubernetes.Runtime.PVC.HostPathPrefix != "" {
+		return c.Kubernetes.Runtime.PVC.HostPathPrefix
+	}
+	return "/data/clawreef"
 }
 
 // GetMode returns the K8s connection mode

--- a/backend/internal/services/k8s/client.go
+++ b/backend/internal/services/k8s/client.go
@@ -29,11 +29,12 @@ const (
 
 // Client wraps the Kubernetes client
 type Client struct {
-	Clientset    *kubernetes.Clientset
-	Config       *rest.Config
-	Namespace    string
-	StorageClass string
-	Mode         ConnectionMode
+	Clientset      *kubernetes.Clientset
+	Config         *rest.Config
+	Namespace      string
+	StorageClass   string
+	HostPathPrefix string
+	Mode           ConnectionMode
 }
 
 var (
@@ -96,11 +97,12 @@ func Initialize(cfg *config.Config) error {
 	}
 
 	globalClient = &Client{
-		Clientset:    clientset,
-		Config:       restConfig,
-		Namespace:    cfg.GetNamespace(),
-		StorageClass: cfg.GetStorageClass(),
-		Mode:         detectedMode,
+		Clientset:      clientset,
+		Config:         restConfig,
+		Namespace:      cfg.GetNamespace(),
+		StorageClass:   cfg.GetStorageClass(),
+		HostPathPrefix: cfg.GetHostPathPrefix(),
+		Mode:           detectedMode,
 	}
 
 	return nil

--- a/backend/internal/services/k8s/pvc_service.go
+++ b/backend/internal/services/k8s/pvc_service.go
@@ -162,8 +162,12 @@ func (s *PVCService) waitForPVCBinding(ctx context.Context, namespace, pvcName s
 // createPVForPVC creates a PV manually to bind to the PVC
 func (s *PVCService) createPVForPVC(ctx context.Context, namespace, pvcName string, userID, instanceID, storageSizeGB int, storageClass string) (*corev1.PersistentVolumeClaim, error) {
 	pvName := fmt.Sprintf("clawreef-pv-user-%d-instance-%d", userID, instanceID)
-	// Use /tmp path to comply with host_path provisioner requirements
-	hostPath := fmt.Sprintf("/tmp/clawreef/user-%d/instance-%d", userID, instanceID)
+	// Use configurable host path prefix for persistent storage
+	hostPathPrefix := "/data/clawreef"
+	if s.client != nil && s.client.HostPathPrefix != "" {
+		hostPathPrefix = s.client.HostPathPrefix
+	}
+	hostPath := fmt.Sprintf("%s/user-%d/instance-%d", hostPathPrefix, userID, instanceID)
 
 	fmt.Printf("Creating PV %s with hostPath %s for PVC %s\n", pvName, hostPath, pvcName)
 

--- a/deployments/k8s/clawmanager.yaml
+++ b/deployments/k8s/clawmanager.yaml
@@ -552,7 +552,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: manual
   hostPath:
-    path: /tmp/clawmanager/system/mysql
+    path: /data/clawmanager/system/mysql
     type: DirectoryOrCreate
 ---
 apiVersion: v1
@@ -582,7 +582,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: manual
   hostPath:
-    path: /tmp/clawmanager/system/minio
+    path: /data/clawmanager/system/minio
     type: DirectoryOrCreate
 ---
 apiVersion: v1
@@ -885,6 +885,8 @@ spec:
               value: "clawmanager"
             - name: K8S_STORAGE_CLASS
               value: "manual"
+            - name: K8S_PV_HOST_PATH_PREFIX
+              value: "/data/clawreef"
             - name: SKILL_SCANNER_ENABLED
               value: "true"
             - name: SKILL_SCANNER_BASE_URL


### PR DESCRIPTION
## Summary

Fixes #110

Changes PV hostPath from volatile `/tmp/clawreef/` to persistent `/data/clawreef/`, making the path configurable via environment variable.

## Changes

- **`backend/internal/config/config.go`**: Add `HostPathPrefix` field to `RuntimePVCConfig`, `GetHostPathPrefix()` method, env var override `K8S_PV_HOST_PATH_PREFIX`
- **`backend/internal/services/k8s/client.go`**: Add `HostPathPrefix` to `Client` struct, pass through in `Initialize()`
- **`backend/internal/services/k8s/pvc_service.go`**: Replace hardcoded `/tmp/clawreef/` with configurable prefix
- **`backend/configs/k8s.yaml`**: Add `hostPathPrefix` config field with documentation
- **`deployments/k8s/clawmanager.yaml`**: Change MySQL and MinIO PV paths from `/tmp/` to `/data/`, add `K8S_PV_HOST_PATH_PREFIX` env var

## Migration

Existing deployments should migrate data before applying this change:
```bash
# On each worker node:
mkdir -p /data/clawreef
cp -a /tmp/clawreef/* /data/clawreef/
rm -rf /tmp/clawreef && ln -s /data/clawreef /tmp/clawreef

# On master node (MySQL + MinIO):
mkdir -p /data/clawmanager
cp -a /tmp/clawmanager/* /data/clawmanager/
rm -rf /tmp/clawmanager && ln -s /data/clawmanager /tmp/clawmanager
```

## Testing

- Verified all 14 running pods continue to work after migration
- Verified MySQL connectivity after master node migration
- Symlinks ensure backward compatibility during transition