### PR TITLE
fix: resolve OpenClaw upload crash with least-privilege pod settings

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -97,7 +97,13 @@ func main() {
 	aiObservabilityService := services.NewAIObservabilityService(modelInvocationRepo, auditEventRepo, costRecordRepo, riskHitRepo, chatMessageRepo, llmModelRepo, instanceRepo, userRepo)
 	clusterResourceService := services.NewClusterResourceService(instanceRepo)
 	services.SetRuntimeImageSettingsProvider(systemImageSettingService)
-	instanceService := services.NewInstanceService(instanceRepo, quotaRepo, llmModelRepo, openClawConfigService)
+	instanceService := services.NewInstanceService(
+		instanceRepo,
+		quotaRepo,
+		llmModelRepo,
+		openClawConfigService,
+		services.WithPrivilegedInstancePods(cfg.Kubernetes.Runtime.Pod.Privileged),
+	)
 	instanceAgentService := services.NewInstanceAgentService(instanceRepo, instanceAgentRepo, instanceDesiredStateRepo, instanceRuntimeStatusRepo, instanceCommandRepo)
 	instanceRuntimeStatusService := services.NewInstanceRuntimeStatusService(instanceRuntimeStatusRepo, instanceAgentRepo, instanceDesiredStateRepo)
 	instanceCommandService := services.NewInstanceCommandService(instanceCommandRepo, instanceRuntimeStatusRepo, instanceDesiredStateRepo)

--- a/backend/internal/services/instance_env.go
+++ b/backend/internal/services/instance_env.go
@@ -4,10 +4,37 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"clawreef/internal/models"
 )
+
+const (
+	defaultInstanceSHMSizeGB = 1
+	maxInstanceSHMSizeGB     = 8
+)
+
+// popSHMSizeGB removes SHM_SIZE_GB from extraEnv and returns /dev/shm size in GiB.
+// Default is 1 when unset. SHM_SIZE_GB=0 disables the custom emptyDir /dev/shm mount.
+// Values above maxInstanceSHMSizeGB are clamped to protect node memory.
+func popSHMSizeGB(extraEnv map[string]string) int {
+	shmSizeGB := defaultInstanceSHMSizeGB
+	if shmVal, ok := extraEnv["SHM_SIZE_GB"]; ok {
+		if parsed, err := strconv.Atoi(strings.TrimSpace(shmVal)); err == nil {
+			if parsed == 0 {
+				shmSizeGB = 0
+			} else if parsed > 0 {
+				shmSizeGB = parsed
+				if shmSizeGB > maxInstanceSHMSizeGB {
+					shmSizeGB = maxInstanceSHMSizeGB
+				}
+			}
+		}
+		delete(extraEnv, "SHM_SIZE_GB")
+	}
+	return shmSizeGB
+}
 
 var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 

--- a/backend/internal/services/instance_env_test.go
+++ b/backend/internal/services/instance_env_test.go
@@ -68,3 +68,39 @@ func TestBuildInstancePodEnvAppliesOverridesAfterDefaults(t *testing.T) {
 		t.Fatalf("expected default environment variable to remain available")
 	}
 }
+
+func TestPopSHMSizeGB(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		hasValue bool
+		want     int
+	}{
+		{name: "default", want: defaultInstanceSHMSizeGB},
+		{name: "disable", value: "0", hasValue: true, want: 0},
+		{name: "custom", value: "4", hasValue: true, want: 4},
+		{name: "clamp", value: "128", hasValue: true, want: maxInstanceSHMSizeGB},
+		{name: "invalid", value: "nope", hasValue: true, want: defaultInstanceSHMSizeGB},
+		{name: "negative", value: "-1", hasValue: true, want: defaultInstanceSHMSizeGB},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extraEnv := map[string]string{"KEEP": "value"}
+			if tt.hasValue {
+				extraEnv["SHM_SIZE_GB"] = tt.value
+			}
+
+			got := popSHMSizeGB(extraEnv)
+			if got != tt.want {
+				t.Fatalf("expected shm size %d, got %d", tt.want, got)
+			}
+			if _, ok := extraEnv["SHM_SIZE_GB"]; ok {
+				t.Fatalf("expected SHM_SIZE_GB to be removed from extra env")
+			}
+			if extraEnv["KEEP"] != "value" {
+				t.Fatalf("expected unrelated env to be preserved")
+			}
+		})
+	}
+}

--- a/backend/internal/services/instance_service.go
+++ b/backend/internal/services/instance_service.go
@@ -76,6 +76,7 @@ type instanceService struct {
 	quotaRepo             repository.QuotaRepository
 	llmModelRepo          repository.LLMModelRepository
 	openClawConfigService OpenClawConfigService
+	allowPrivilegedPods   bool
 	podService            *k8s.PodService
 	pvcService            *k8s.PVCService
 	serviceService        *k8s.ServiceService
@@ -87,9 +88,17 @@ type gatewayModelInjection struct {
 	modelsJSON   string
 }
 
+type InstanceServiceOption func(*instanceService)
+
+func WithPrivilegedInstancePods(allowed bool) InstanceServiceOption {
+	return func(s *instanceService) {
+		s.allowPrivilegedPods = allowed
+	}
+}
+
 // NewInstanceService creates a new instance service
-func NewInstanceService(instanceRepo repository.InstanceRepository, quotaRepo repository.QuotaRepository, llmModelRepo repository.LLMModelRepository, openClawConfigService OpenClawConfigService) InstanceService {
-	return &instanceService{
+func NewInstanceService(instanceRepo repository.InstanceRepository, quotaRepo repository.QuotaRepository, llmModelRepo repository.LLMModelRepository, openClawConfigService OpenClawConfigService, options ...InstanceServiceOption) InstanceService {
+	service := &instanceService{
 		instanceRepo:          instanceRepo,
 		quotaRepo:             quotaRepo,
 		llmModelRepo:          llmModelRepo,
@@ -99,6 +108,12 @@ func NewInstanceService(instanceRepo repository.InstanceRepository, quotaRepo re
 		serviceService:        k8s.NewServiceService(),
 		networkPolicyService:  k8s.NewNetworkPolicyService(),
 	}
+	for _, option := range options {
+		if option != nil {
+			option(service)
+		}
+	}
+	return service
 }
 
 // Create creates a new instance
@@ -302,6 +317,7 @@ func (s *instanceService) Create(userID int, req CreateInstanceRequest) (*models
 	}
 
 	// Create Pod
+	shmSizeGB := popSHMSizeGB(extraEnv)
 	podConfig := k8s.PodConfig{
 		InstanceID:         instance.ID,
 		InstanceName:       instance.Name,
@@ -317,6 +333,8 @@ func (s *instanceService) Create(userID int, req CreateInstanceRequest) (*models
 		ImagePullPolicy:    corev1.PullPolicy(defaultImagePullPolicy()),
 		ExtraEnv:           extraEnv,
 		EnvFromSecretNames: []string{bootstrapSecretName},
+		SHMSizeGB:          shmSizeGB,
+		SecurityMode:       s.securityModeForInstance(instance.Type),
 	}
 
 	pod, err := s.podService.CreatePod(ctx, podConfig)
@@ -470,6 +488,7 @@ func (s *instanceService) Start(instanceID int) error {
 		return fmt.Errorf("failed to delete network policy: %w", err)
 	}
 
+	shmSizeGB := popSHMSizeGB(extraEnv)
 	podConfig := k8s.PodConfig{
 		InstanceID:         instance.ID,
 		InstanceName:       instance.Name,
@@ -485,6 +504,8 @@ func (s *instanceService) Start(instanceID int) error {
 		ImagePullPolicy:    corev1.PullPolicy(defaultImagePullPolicy()),
 		ExtraEnv:           extraEnv,
 		EnvFromSecretNames: []string{bootstrapSecretName},
+		SHMSizeGB:          shmSizeGB,
+		SecurityMode:       s.securityModeForInstance(instance.Type),
 	}
 
 	pod, err := s.podService.CreatePod(ctx, podConfig)
@@ -527,6 +548,16 @@ func (s *instanceService) Start(instanceID int) error {
 	GetHub().BroadcastInstanceStatus(instance.UserID, instance)
 
 	return nil
+}
+
+func (s *instanceService) securityModeForInstance(instanceType string) k8s.PodSecurityMode {
+	if s != nil && s.allowPrivilegedPods {
+		return k8s.PodSecurityPrivileged
+	}
+	if strings.EqualFold(strings.TrimSpace(instanceType), "openclaw") {
+		return k8s.PodSecurityChromiumCompat
+	}
+	return k8s.PodSecurityDefault
 }
 
 func (s *instanceService) ensureGatewayToken(instance *models.Instance) (string, error) {

--- a/backend/internal/services/instance_service_test.go
+++ b/backend/internal/services/instance_service_test.go
@@ -141,3 +141,19 @@ func TestResolveGatewayModelInjectionRequiresActiveModels(t *testing.T) {
 		t.Fatalf("expected resolveGatewayModelInjection to fail when no active models exist, got %#v", injection)
 	}
 }
+
+func TestSecurityModeForInstance(t *testing.T) {
+	service := &instanceService{}
+
+	if got := service.securityModeForInstance("openclaw"); got != "chromium-compat" {
+		t.Fatalf("expected openclaw to use chromium compat mode, got %q", got)
+	}
+	if got := service.securityModeForInstance("ubuntu"); got != "default" {
+		t.Fatalf("expected ubuntu to use default security mode, got %q", got)
+	}
+
+	service.allowPrivilegedPods = true
+	if got := service.securityModeForInstance("openclaw"); got != "privileged" {
+		t.Fatalf("expected explicit privileged override to win, got %q", got)
+	}
+}

--- a/backend/internal/services/k8s/client.go
+++ b/backend/internal/services/k8s/client.go
@@ -29,7 +29,7 @@ const (
 
 // Client wraps the Kubernetes client
 type Client struct {
-	Clientset      *kubernetes.Clientset
+	Clientset      kubernetes.Interface
 	Config         *rest.Config
 	Namespace      string
 	StorageClass   string

--- a/backend/internal/services/k8s/pod_service.go
+++ b/backend/internal/services/k8s/pod_service.go
@@ -17,9 +17,15 @@ type PodService struct {
 	client *Client
 }
 
+type PodSecurityMode string
+
 const (
 	podDeletionPollInterval = 500 * time.Millisecond
 	podDeletionTimeout      = 60 * time.Second
+
+	PodSecurityDefault        PodSecurityMode = "default"
+	PodSecurityChromiumCompat PodSecurityMode = "chromium-compat"
+	PodSecurityPrivileged     PodSecurityMode = "privileged"
 )
 
 // NewPodService creates a new Pod service
@@ -50,6 +56,8 @@ type PodConfig struct {
 	ImagePullPolicy    corev1.PullPolicy
 	ExtraEnv           map[string]string
 	EnvFromSecretNames []string
+	SHMSizeGB          int
+	SecurityMode       PodSecurityMode
 }
 
 // CreatePod creates a new pod for an instance
@@ -93,10 +101,16 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 		pullPolicy = corev1.PullIfNotPresent
 	}
 
+	annotations := map[string]string{}
+	if config.SecurityMode == PodSecurityChromiumCompat {
+		annotations["container.apparmor.security.beta.kubernetes.io/desktop"] = "unconfined"
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
+			Name:        podName,
+			Namespace:   namespace,
+			Annotations: annotations,
 			Labels: map[string]string{
 				"app":           "clawreef",
 				"instance-id":   fmt.Sprintf("%d", config.InstanceID),
@@ -151,7 +165,8 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 						TimeoutSeconds:      2,
 						FailureThreshold:    3,
 					},
-					Resources: resources,
+					SecurityContext: buildContainerSecurityContext(config.SecurityMode),
+					Resources:       resources,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "data",
@@ -187,6 +202,23 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
 			Name:  key,
 			Value: value,
+		})
+	}
+
+	if config.SHMSizeGB > 0 {
+		shmLimit := resource.MustParse(fmt.Sprintf("%dGi", config.SHMSizeGB))
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: "shm",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium:    corev1.StorageMediumMemory,
+					SizeLimit: &shmLimit,
+				},
+			},
+		})
+		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      "shm",
+			MountPath: "/dev/shm",
 		})
 	}
 
@@ -231,6 +263,26 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 	}
 
 	return createdPod, nil
+}
+
+func buildContainerSecurityContext(mode PodSecurityMode) *corev1.SecurityContext {
+	switch mode {
+	case PodSecurityChromiumCompat:
+		allowPrivilegeEscalation := true
+		return &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeUnconfined,
+			},
+		}
+	case PodSecurityPrivileged:
+		privileged := true
+		return &corev1.SecurityContext{
+			Privileged: &privileged,
+		}
+	default:
+		return nil
+	}
 }
 
 func intstrFromInt32(port int32) intstr.IntOrString {

--- a/backend/internal/services/k8s/pod_service_test.go
+++ b/backend/internal/services/k8s/pod_service_test.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestBuildContainerSecurityContext(t *testing.T) {
+	if got := buildContainerSecurityContext(PodSecurityDefault); got != nil {
+		t.Fatalf("expected default security mode to leave securityContext unset, got %#v", got)
+	}
+
+	chromium := buildContainerSecurityContext(PodSecurityChromiumCompat)
+	if chromium == nil {
+		t.Fatalf("expected chromium compat security context")
+	}
+	if chromium.Privileged != nil && *chromium.Privileged {
+		t.Fatalf("chromium compat mode must not enable privileged")
+	}
+	if chromium.AllowPrivilegeEscalation == nil || !*chromium.AllowPrivilegeEscalation {
+		t.Fatalf("expected chromium compat mode to allow privilege escalation for browser sandbox helpers")
+	}
+	if chromium.SeccompProfile == nil || chromium.SeccompProfile.Type != "Unconfined" {
+		t.Fatalf("expected chromium compat mode to use unconfined seccomp profile, got %#v", chromium.SeccompProfile)
+	}
+
+	privileged := buildContainerSecurityContext(PodSecurityPrivileged)
+	if privileged == nil || privileged.Privileged == nil || !*privileged.Privileged {
+		t.Fatalf("expected privileged mode to enable privileged security context")
+	}
+}
+
+func TestCreatePodAppliesSecurityModes(t *testing.T) {
+	previousClient := globalClient
+	t.Cleanup(func() {
+		globalClient = previousClient
+	})
+
+	globalClient = &Client{
+		Clientset:    fake.NewSimpleClientset(),
+		Namespace:    "clawreef",
+		StorageClass: "standard",
+	}
+
+	service := NewPodService()
+	pod, err := service.CreatePod(context.Background(), PodConfig{
+		InstanceID:    42,
+		InstanceName:  "openclaw-test",
+		UserID:        7,
+		Type:          "openclaw",
+		CPUCores:      1,
+		MemoryGB:      2,
+		Image:         "openclaw:test",
+		MountPath:     "/config",
+		ContainerPort: 3001,
+		SHMSizeGB:     1,
+		SecurityMode:  PodSecurityChromiumCompat,
+	})
+	if err != nil {
+		t.Fatalf("CreatePod returned error: %v", err)
+	}
+
+	container := pod.Spec.Containers[0]
+	if container.SecurityContext == nil {
+		t.Fatalf("expected chromium compat security context")
+	}
+	if container.SecurityContext.Privileged != nil && *container.SecurityContext.Privileged {
+		t.Fatalf("chromium compat pod must not be privileged")
+	}
+	if pod.Annotations["container.apparmor.security.beta.kubernetes.io/desktop"] != "unconfined" {
+		t.Fatalf("expected apparmor unconfined annotation for chromium compat mode, got %#v", pod.Annotations)
+	}
+	if len(pod.Spec.Volumes) != 2 {
+		t.Fatalf("expected data and shm volumes, got %d", len(pod.Spec.Volumes))
+	}
+}

--- a/backend/internal/services/security_scan_service.go
+++ b/backend/internal/services/security_scan_service.go
@@ -759,7 +759,7 @@ func upsertEnvVar(container *corev1.Container, name, value string) {
 	container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
 }
 
-func waitForSkillScannerRollout(ctx context.Context, clientset *kubernetes.Clientset, namespace, deploymentName string, generation int64, timeout time.Duration) error {
+func waitForSkillScannerRollout(ctx context.Context, clientset kubernetes.Interface, namespace, deploymentName string, generation int64, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})

--- a/deployments/k3s/clawmanager.yaml
+++ b/deployments/k3s/clawmanager.yaml
@@ -655,8 +655,10 @@ spec:
           image: ghcr.io/yuan-lab-llm/clawmanager:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - name: http
+            - name: https
               containerPort: 8443
+            - name: proxy
+              containerPort: 9001
           env:
             - name: SERVER_ADDRESS
               value: ":9001"
@@ -704,7 +706,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8443
+              port: https
               scheme: HTTPS
             initialDelaySeconds: 10
             periodSeconds: 5
@@ -712,7 +714,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8443
+              port: https
               scheme: HTTPS
             initialDelaySeconds: 30
             periodSeconds: 20
@@ -733,7 +735,7 @@ spec:
   ports:
     - name: https
       port: 443
-      targetPort: 8443
+      targetPort: https
       nodePort: 30443
 ---
 apiVersion: v1
@@ -747,8 +749,8 @@ spec:
     app: clawmanager-app
   ports:
     - name: api
-      port: 8443
-      targetPort: 8443
+      port: 9001
+      targetPort: 9001
 ---
 apiVersion: v1
 kind: Service
@@ -762,7 +764,7 @@ spec:
   ports:
     - name: proxy
       port: 3128
-      targetPort: 8443
+      targetPort: 9001
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
- add configurable /dev/shm mounts for instance pods with a bounded SHM_SIZE_GB override
- introduce pod security modes and use chromium-compat for OpenClaw instead of privileged
- keep privileged mode only as an explicit admin fallback
- remove the node-level clawmanager-node-tuner manifest to avoid changing host security defaults
- fix k3s HTTPS and API/proxy service port mappings
- add tests for SHM parsing and pod security mode behavior