### PR TITLE
feat: add Bundle Skills, WeCom channel, configurable archive limit

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -237,7 +237,9 @@ func main() {
 			teams.POST("", teamHandler.CreateTeam)
 			teams.GET("/:id", teamHandler.GetTeam)
 			teams.DELETE("/:id", teamHandler.DeleteTeam)
+			teams.GET("/:id/tasks", teamHandler.ListTasks)
 			teams.POST("/:id/tasks", teamHandler.DispatchTask)
+			teams.GET("/:id/events", teamHandler.ListEvents)
 			teams.DELETE("/:id/members/:memberID", teamHandler.DeleteMember)
 		}
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -89,7 +89,7 @@ func main() {
 	riskDetectionService := services.NewRiskDetectionService(riskRuleRepo)
 	riskHitService := services.NewRiskHitService(riskHitRepo)
 	riskRuleService := services.NewRiskRuleService(riskRuleRepo)
-	openClawConfigService := services.NewOpenClawConfigService(openClawConfigRepo)
+	openClawConfigService := services.NewOpenClawConfigService(openClawConfigRepo, skillRepo)
 	objectStorageService, err := services.NewObjectStorageService(cfg.ObjectStorage)
 	if err != nil {
 		log.Fatalf("Failed to initialize object storage: %v", err)

--- a/backend/deployments/docker/docker-compose.yml
+++ b/backend/deployments/docker/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       DB_PASSWORD: "clawreef123"
       DB_NAME: "clawreef"
       JWT_SECRET: "clawreef-dev-secret-key"
+      CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB: "500"
     ports:
       - "9001:9001"
     depends_on:

--- a/backend/deployments/k8s/clawreef-incluster.yaml
+++ b/backend/deployments/k8s/clawreef-incluster.yaml
@@ -428,6 +428,20 @@ data:
       WHERE instance_type = 'openclaw'
         AND is_enabled = FALSE
     );
+  022_add_openclaw_config_bundle_skills.sql: |
+    USE clawreef;
+    CREATE TABLE IF NOT EXISTS openclaw_config_bundle_skills (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      bundle_id INT NOT NULL,
+      skill_id INT NOT NULL,
+      sort_order INT NOT NULL DEFAULT 0,
+      required BOOLEAN NOT NULL DEFAULT TRUE,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (bundle_id) REFERENCES openclaw_config_bundles(id) ON DELETE CASCADE,
+      FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE,
+      UNIQUE KEY uk_openclaw_bundle_skill (bundle_id, skill_id),
+      INDEX idx_openclaw_bundle_skill_bundle (bundle_id, sort_order)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -578,6 +592,8 @@ spec:
               value: "clawreef"
             - name: K8S_STORAGE_CLASS
               value: "local-path"
+            - name: CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB
+              value: "500"
           readinessProbe:
             tcpSocket:
               port: 9001

--- a/backend/internal/db/migrations/022_add_openclaw_config_bundle_skills.sql
+++ b/backend/internal/db/migrations/022_add_openclaw_config_bundle_skills.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS openclaw_config_bundle_skills (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  bundle_id INT NOT NULL,
+  skill_id INT NOT NULL,
+  sort_order INT NOT NULL DEFAULT 0,
+  required BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (bundle_id) REFERENCES openclaw_config_bundles(id) ON DELETE CASCADE,
+  FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE,
+  UNIQUE KEY uk_openclaw_bundle_skill (bundle_id, skill_id),
+  INDEX idx_openclaw_bundle_skill_bundle (bundle_id, sort_order)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/internal/handlers/instance_handler.go
+++ b/backend/internal/handlers/instance_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -22,12 +23,26 @@ import (
 // stream from the exec pipeline rather than a real workspace dump.
 const openclawMinArchiveBytes = 100
 
-// openclawMaxUploadBytes caps the size of an .openclaw import upload.
-// Must align with the edge nginx client_max_body_size so that oversize
-// uploads produce a structured JSON 413 here instead of an opaque HTML
-// 413 from nginx. See ClawManager/deployments/nginx/nginx.conf and
-// deployment/nginx-conf.yaml.
-const openclawMaxUploadBytes = 50 << 20 // 50 MiB
+const (
+	defaultWorkspaceArchiveMaxMiB = int64(500)
+	workspaceArchiveMaxMiBEnv     = "CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB"
+)
+
+func workspaceArchiveMaxMiB() int64 {
+	value := strings.TrimSpace(os.Getenv(workspaceArchiveMaxMiBEnv))
+	if value == "" {
+		return defaultWorkspaceArchiveMaxMiB
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || parsed <= 0 {
+		return defaultWorkspaceArchiveMaxMiB
+	}
+	return parsed
+}
+
+func workspaceArchiveMaxBytes() int64 {
+	return workspaceArchiveMaxMiB() << 20
+}
 
 // InstanceHandler handles instance management requests
 type InstanceHandler struct {
@@ -216,7 +231,13 @@ func (h *InstanceHandler) CreateInstance(c *gin.Context) {
 		return
 	}
 
-	for _, skillID := range req.SkillIDs {
+	skillIDs, err := h.resolveCreateInstanceSkillIDs(userID.(int), req)
+	if err != nil {
+		utils.HandleError(c, err)
+		return
+	}
+
+	for _, skillID := range skillIDs {
 		if _, err := h.skillService.AttachSkillToInstance(instance.ID, skillID); err != nil {
 			utils.HandleError(c, err)
 			return
@@ -224,6 +245,40 @@ func (h *InstanceHandler) CreateInstance(c *gin.Context) {
 	}
 
 	utils.Success(c, http.StatusCreated, "Instance created successfully", instance)
+}
+
+func (h *InstanceHandler) resolveCreateInstanceSkillIDs(userID int, req CreateInstanceRequest) ([]int, error) {
+	seen := map[int]struct{}{}
+	result := make([]int, 0, len(req.SkillIDs))
+	for _, skillID := range req.SkillIDs {
+		if skillID <= 0 {
+			continue
+		}
+		if _, exists := seen[skillID]; exists {
+			continue
+		}
+		seen[skillID] = struct{}{}
+		result = append(result, skillID)
+	}
+
+	if h.openClawConfigService != nil {
+		bundleSkillIDs, err := h.openClawConfigService.ResolveBundleSkillIDs(userID, req.OpenClawConfigPlan)
+		if err != nil {
+			return nil, err
+		}
+		for _, skillID := range bundleSkillIDs {
+			if skillID <= 0 {
+				continue
+			}
+			if _, exists := seen[skillID]; exists {
+				continue
+			}
+			seen[skillID] = struct{}{}
+			result = append(result, skillID)
+		}
+	}
+
+	return result, nil
 }
 
 // GetInstance gets an instance by ID
@@ -955,6 +1010,12 @@ func (h *InstanceHandler) ExportOpenClaw(c *gin.Context) {
 		utils.Error(c, http.StatusInternalServerError, "export produced an empty archive")
 		return
 	}
+	maxArchiveBytes := workspaceArchiveMaxBytes()
+	if int64(len(archive)) > maxArchiveBytes {
+		utils.Error(c, http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("archive too large; maximum archive size is %d MiB", maxArchiveBytes>>20))
+		return
+	}
 
 	filename := fmt.Sprintf("%s.openclaw.tar.gz", sanitizeDownloadName(instance.Name))
 	c.Header("Content-Type", "application/gzip")
@@ -993,6 +1054,12 @@ func (h *InstanceHandler) ExportHermes(c *gin.Context) {
 		utils.Error(c, http.StatusInternalServerError, "export produced an empty archive")
 		return
 	}
+	maxArchiveBytes := workspaceArchiveMaxBytes()
+	if int64(len(archive)) > maxArchiveBytes {
+		utils.Error(c, http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("archive too large; maximum archive size is %d MiB", maxArchiveBytes>>20))
+		return
+	}
 
 	filename := fmt.Sprintf("%s.hermes.tar.gz", sanitizeDownloadName(instance.Name, "hermes-workspace"))
 	c.Header("Content-Type", "application/gzip")
@@ -1017,27 +1084,27 @@ func (h *InstanceHandler) ImportOpenClaw(c *gin.Context) {
 		return
 	}
 
-	// Cap the request body early so oversize uploads fail with a structured
-	// JSON 413 instead of nginx's opaque HTML 413 or a surprise ENOSPC deep
-	// inside multipart parsing. MaxBytesReader trips ParseMultipartForm
+	// Cap the request body at the same deployment limit used by nginx. When
+	// the request reaches the backend, MaxBytesReader trips ParseMultipartForm
 	// (invoked by c.FormFile) with a typed *http.MaxBytesError.
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, openclawMaxUploadBytes)
+	maxArchiveBytes := workspaceArchiveMaxBytes()
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxArchiveBytes)
 
 	fileHeader, err := c.FormFile("file")
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			utils.Error(c, http.StatusRequestEntityTooLarge,
-				fmt.Sprintf("archive too large; maximum upload size is %d MiB", openclawMaxUploadBytes>>20))
+				fmt.Sprintf("archive too large; maximum upload size is %d MiB", maxArchiveBytes>>20))
 			return
 		}
 		utils.Error(c, http.StatusBadRequest, "file is required")
 		return
 	}
 
-	if fileHeader.Size > openclawMaxUploadBytes {
+	if fileHeader.Size > maxArchiveBytes {
 		utils.Error(c, http.StatusRequestEntityTooLarge,
-			fmt.Sprintf("archive too large; maximum upload size is %d MiB", openclawMaxUploadBytes>>20))
+			fmt.Sprintf("archive too large; maximum upload size is %d MiB", maxArchiveBytes>>20))
 		return
 	}
 
@@ -1048,7 +1115,7 @@ func (h *InstanceHandler) ImportOpenClaw(c *gin.Context) {
 	}
 	defer file.Close()
 
-	if err := h.openClawTransferService.Import(c.Request.Context(), instance.UserID, instance.ID, io.LimitReader(file, openclawMaxUploadBytes)); err != nil {
+	if err := h.openClawTransferService.Import(c.Request.Context(), instance.UserID, instance.ID, io.LimitReader(file, maxArchiveBytes)); err != nil {
 		utils.HandleError(c, err)
 		return
 	}
@@ -1072,23 +1139,24 @@ func (h *InstanceHandler) ImportHermes(c *gin.Context) {
 		return
 	}
 
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, openclawMaxUploadBytes)
+	maxArchiveBytes := workspaceArchiveMaxBytes()
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxArchiveBytes)
 
 	fileHeader, err := c.FormFile("file")
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			utils.Error(c, http.StatusRequestEntityTooLarge,
-				fmt.Sprintf("archive too large; maximum upload size is %d MiB", openclawMaxUploadBytes>>20))
+				fmt.Sprintf("archive too large; maximum upload size is %d MiB", maxArchiveBytes>>20))
 			return
 		}
 		utils.Error(c, http.StatusBadRequest, "file is required")
 		return
 	}
 
-	if fileHeader.Size > openclawMaxUploadBytes {
+	if fileHeader.Size > maxArchiveBytes {
 		utils.Error(c, http.StatusRequestEntityTooLarge,
-			fmt.Sprintf("archive too large; maximum upload size is %d MiB", openclawMaxUploadBytes>>20))
+			fmt.Sprintf("archive too large; maximum upload size is %d MiB", maxArchiveBytes>>20))
 		return
 	}
 
@@ -1099,7 +1167,7 @@ func (h *InstanceHandler) ImportHermes(c *gin.Context) {
 	}
 	defer file.Close()
 
-	if err := h.openClawTransferService.ImportHermes(c.Request.Context(), instance.UserID, instance.ID, io.LimitReader(file, openclawMaxUploadBytes)); err != nil {
+	if err := h.openClawTransferService.ImportHermes(c.Request.Context(), instance.UserID, instance.ID, io.LimitReader(file, maxArchiveBytes)); err != nil {
 		utils.HandleError(c, err)
 		return
 	}

--- a/backend/internal/handlers/instance_handler_test.go
+++ b/backend/internal/handlers/instance_handler_test.go
@@ -1,0 +1,25 @@
+package handlers
+
+import "testing"
+
+func TestWorkspaceArchiveMaxMiB(t *testing.T) {
+	t.Setenv(workspaceArchiveMaxMiBEnv, "")
+	if got := workspaceArchiveMaxMiB(); got != defaultWorkspaceArchiveMaxMiB {
+		t.Fatalf("expected default archive limit %d MiB, got %d", defaultWorkspaceArchiveMaxMiB, got)
+	}
+
+	t.Setenv(workspaceArchiveMaxMiBEnv, "750")
+	if got := workspaceArchiveMaxMiB(); got != 750 {
+		t.Fatalf("expected env archive limit 750 MiB, got %d", got)
+	}
+
+	t.Setenv(workspaceArchiveMaxMiBEnv, "0")
+	if got := workspaceArchiveMaxMiB(); got != defaultWorkspaceArchiveMaxMiB {
+		t.Fatalf("expected invalid archive limit to fall back to %d MiB, got %d", defaultWorkspaceArchiveMaxMiB, got)
+	}
+
+	t.Setenv(workspaceArchiveMaxMiBEnv, "not-a-number")
+	if got := workspaceArchiveMaxMiB(); got != defaultWorkspaceArchiveMaxMiB {
+		t.Fatalf("expected unparsable archive limit to fall back to %d MiB, got %d", defaultWorkspaceArchiveMaxMiB, got)
+	}
+}

--- a/backend/internal/handlers/team_handler.go
+++ b/backend/internal/handlers/team_handler.go
@@ -71,6 +71,44 @@ func (h *TeamHandler) GetTeam(c *gin.Context) {
 	utils.Success(c, http.StatusOK, "Team retrieved successfully", team)
 }
 
+func (h *TeamHandler) ListTasks(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	teamID, ok := parseTeamID(c)
+	if !ok {
+		return
+	}
+	tasks, err := h.teamService.ListTeamTasks(
+		userID.(int),
+		teamID,
+		parseOptionalIntQuery(c, "before_id"),
+		parseOptionalIntQuery(c, "limit"),
+	)
+	if err != nil {
+		utils.HandleError(c, err)
+		return
+	}
+	utils.Success(c, http.StatusOK, "Team tasks retrieved successfully", tasks)
+}
+
+func (h *TeamHandler) ListEvents(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	teamID, ok := parseTeamID(c)
+	if !ok {
+		return
+	}
+	events, err := h.teamService.ListTeamEvents(
+		userID.(int),
+		teamID,
+		parseOptionalIntQuery(c, "before_id"),
+		parseOptionalIntQuery(c, "limit"),
+	)
+	if err != nil {
+		utils.HandleError(c, err)
+		return
+	}
+	utils.Success(c, http.StatusOK, "Team events retrieved successfully", events)
+}
+
 func (h *TeamHandler) DispatchTask(c *gin.Context) {
 	userID, _ := c.Get("userID")
 	teamID, ok := parseTeamID(c)
@@ -125,4 +163,16 @@ func parseTeamID(c *gin.Context) (int, bool) {
 		return 0, false
 	}
 	return id, true
+}
+
+func parseOptionalIntQuery(c *gin.Context, key string) int {
+	raw := c.Query(key)
+	if raw == "" {
+		return 0
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return 0
+	}
+	return value
 }

--- a/backend/internal/models/openclaw_config.go
+++ b/backend/internal/models/openclaw_config.go
@@ -51,6 +51,20 @@ func (i OpenClawConfigBundleItem) TableName() string {
 	return "openclaw_config_bundle_items"
 }
 
+// OpenClawConfigBundleSkill stores an uploaded skill membership inside a bundle.
+type OpenClawConfigBundleSkill struct {
+	ID        int       `db:"id,primarykey,autoincrement" json:"id"`
+	BundleID  int       `db:"bundle_id" json:"bundle_id"`
+	SkillID   int       `db:"skill_id" json:"skill_id"`
+	SortOrder int       `db:"sort_order" json:"sort_order"`
+	Required  bool      `db:"required" json:"required"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+}
+
+func (i OpenClawConfigBundleSkill) TableName() string {
+	return "openclaw_config_bundle_skills"
+}
+
 // OpenClawInjectionSnapshot stores the rendered bootstrap payload used by an instance.
 type OpenClawInjectionSnapshot struct {
 	ID                      int        `db:"id,primarykey,autoincrement" json:"id"`

--- a/backend/internal/repository/openclaw_config_repository.go
+++ b/backend/internal/repository/openclaw_config_repository.go
@@ -25,6 +25,8 @@ type OpenClawConfigRepository interface {
 	DeleteBundle(id int) error
 	ListBundleItems(bundleID int) ([]models.OpenClawConfigBundleItem, error)
 	ReplaceBundleItems(bundleID int, items []models.OpenClawConfigBundleItem) error
+	ListBundleSkills(bundleID int) ([]models.OpenClawConfigBundleSkill, error)
+	ReplaceBundleSkills(bundleID int, items []models.OpenClawConfigBundleSkill) error
 
 	CreateSnapshot(snapshot *models.OpenClawInjectionSnapshot) error
 	UpdateSnapshot(snapshot *models.OpenClawInjectionSnapshot) error
@@ -168,6 +170,29 @@ func (r *openClawConfigRepository) ReplaceBundleItems(bundleID int, items []mode
 		item.BundleID = bundleID
 		if _, err := r.sess.Collection("openclaw_config_bundle_items").Insert(item); err != nil {
 			return fmt.Errorf("failed to add openclaw config bundle item: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *openClawConfigRepository) ListBundleSkills(bundleID int) ([]models.OpenClawConfigBundleSkill, error) {
+	var items []models.OpenClawConfigBundleSkill
+	if err := r.sess.Collection("openclaw_config_bundle_skills").Find(db.Cond{"bundle_id": bundleID}).OrderBy("sort_order", "id").All(&items); err != nil {
+		return nil, fmt.Errorf("failed to list openclaw config bundle skills: %w", err)
+	}
+	return items, nil
+}
+
+func (r *openClawConfigRepository) ReplaceBundleSkills(bundleID int, items []models.OpenClawConfigBundleSkill) error {
+	if err := r.sess.Collection("openclaw_config_bundle_skills").Find(db.Cond{"bundle_id": bundleID}).Delete(); err != nil && err != db.ErrNoMoreRows {
+		return fmt.Errorf("failed to delete existing openclaw config bundle skills: %w", err)
+	}
+
+	for _, item := range items {
+		item.BundleID = bundleID
+		if _, err := r.sess.Collection("openclaw_config_bundle_skills").Insert(item); err != nil {
+			return fmt.Errorf("failed to add openclaw config bundle skill: %w", err)
 		}
 	}
 

--- a/backend/internal/repository/team_repository.go
+++ b/backend/internal/repository/team_repository.go
@@ -31,11 +31,13 @@ type TeamRepository interface {
 	GetTaskByID(id int) (*models.TeamTask, error)
 	GetTaskByMessageID(teamID int, messageID string) (*models.TeamTask, error)
 	ListTasksByTeamID(teamID int, limit int) ([]models.TeamTask, error)
+	ListTasksBeforeID(teamID, beforeID, limit int) ([]models.TeamTask, error)
 	ListStaleCandidateTasks(cutoff time.Time, limit int) ([]models.TeamTask, error)
 
 	CreateEvent(event *models.TeamEvent) error
 	EventExistsByStreamID(teamID int, streamID string) (bool, error)
 	ListEventsByTeamID(teamID int, limit int) ([]models.TeamEvent, error)
+	ListEventsBeforeID(teamID, beforeID, limit int) ([]models.TeamEvent, error)
 }
 
 type teamRepository struct {
@@ -235,6 +237,21 @@ func (r *teamRepository) ListTasksByTeamID(teamID int, limit int) ([]models.Team
 	return tasks, nil
 }
 
+func (r *teamRepository) ListTasksBeforeID(teamID, beforeID, limit int) ([]models.TeamTask, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	cond := db.Cond{"team_id": teamID}
+	if beforeID > 0 {
+		cond["id <"] = beforeID
+	}
+	var tasks []models.TeamTask
+	if err := r.sess.Collection("team_tasks").Find(cond).OrderBy("-created_at", "-id").Limit(limit).All(&tasks); err != nil {
+		return nil, fmt.Errorf("failed to list team task history: %w", err)
+	}
+	return tasks, nil
+}
+
 func (r *teamRepository) ListStaleCandidateTasks(cutoff time.Time, limit int) ([]models.TeamTask, error) {
 	if limit <= 0 {
 		limit = 100
@@ -285,6 +302,21 @@ func (r *teamRepository) ListEventsByTeamID(teamID int, limit int) ([]models.Tea
 	var events []models.TeamEvent
 	if err := r.sess.Collection("team_events").Find(db.Cond{"team_id": teamID}).OrderBy("-created_at", "-id").Limit(limit).All(&events); err != nil {
 		return nil, fmt.Errorf("failed to list team events: %w", err)
+	}
+	return events, nil
+}
+
+func (r *teamRepository) ListEventsBeforeID(teamID, beforeID, limit int) ([]models.TeamEvent, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	cond := db.Cond{"team_id": teamID}
+	if beforeID > 0 {
+		cond["id <"] = beforeID
+	}
+	var events []models.TeamEvent
+	if err := r.sess.Collection("team_events").Find(cond).OrderBy("-created_at", "-id").Limit(limit).All(&events); err != nil {
+		return nil, fmt.Errorf("failed to list team event history: %w", err)
 	}
 	return events, nil
 }

--- a/backend/internal/services/openclaw_config_service.go
+++ b/backend/internal/services/openclaw_config_service.go
@@ -168,23 +168,47 @@ type OpenClawConfigBundleItemPayload struct {
 	Resource   *OpenClawConfigResourceSummary `json:"resource,omitempty"`
 }
 
+type OpenClawConfigBundleSkillSummary struct {
+	ID               int        `json:"id"`
+	UserID           int        `json:"user_id"`
+	SkillKey         string     `json:"skill_key"`
+	Name             string     `json:"name"`
+	Description      *string    `json:"description,omitempty"`
+	Status           string     `json:"status"`
+	SourceType       string     `json:"source_type"`
+	RiskLevel        string     `json:"risk_level"`
+	CurrentVersionID *int       `json:"current_version_id,omitempty"`
+	LastScannedAt    *time.Time `json:"last_scanned_at,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+}
+
+type OpenClawConfigBundleSkillPayload struct {
+	SkillID   int                               `json:"skill_id"`
+	SortOrder int                               `json:"sort_order"`
+	Required  bool                              `json:"required"`
+	Skill     *OpenClawConfigBundleSkillSummary `json:"skill,omitempty"`
+}
+
 type OpenClawConfigBundlePayload struct {
-	ID          int                               `json:"id"`
-	UserID      int                               `json:"user_id"`
-	Name        string                            `json:"name"`
-	Description *string                           `json:"description,omitempty"`
-	Enabled     bool                              `json:"enabled"`
-	Version     int                               `json:"version"`
-	Items       []OpenClawConfigBundleItemPayload `json:"items"`
-	CreatedAt   time.Time                         `json:"created_at"`
-	UpdatedAt   time.Time                         `json:"updated_at"`
+	ID          int                                `json:"id"`
+	UserID      int                                `json:"user_id"`
+	Name        string                             `json:"name"`
+	Description *string                            `json:"description,omitempty"`
+	Enabled     bool                               `json:"enabled"`
+	Version     int                                `json:"version"`
+	Items       []OpenClawConfigBundleItemPayload  `json:"items"`
+	SkillItems  []OpenClawConfigBundleSkillPayload `json:"skill_items"`
+	CreatedAt   time.Time                          `json:"created_at"`
+	UpdatedAt   time.Time                          `json:"updated_at"`
 }
 
 type UpsertOpenClawConfigBundleRequest struct {
-	Name        string                            `json:"name"`
-	Description *string                           `json:"description,omitempty"`
-	Enabled     bool                              `json:"enabled"`
-	Items       []OpenClawConfigBundleItemPayload `json:"items"`
+	Name        string                             `json:"name"`
+	Description *string                            `json:"description,omitempty"`
+	Enabled     bool                               `json:"enabled"`
+	Items       []OpenClawConfigBundleItemPayload  `json:"items"`
+	SkillItems  []OpenClawConfigBundleSkillPayload `json:"skill_items"`
 }
 
 type OpenClawConfigCompilePreview struct {
@@ -234,6 +258,7 @@ type OpenClawConfigService interface {
 	UpdateBundle(userID, id int, req UpsertOpenClawConfigBundleRequest) (*OpenClawConfigBundlePayload, error)
 	DeleteBundle(userID, id int) error
 	CloneBundle(userID, id int) (*OpenClawConfigBundlePayload, error)
+	ResolveBundleSkillIDs(userID int, plan *OpenClawConfigPlan) ([]int, error)
 
 	CompilePreview(userID int, plan OpenClawConfigPlan) (*OpenClawConfigCompilePreview, error)
 	CreateSnapshotForInstance(userID int, instance *models.Instance, plan *OpenClawConfigPlan) (*models.OpenClawInjectionSnapshot, error)
@@ -246,6 +271,7 @@ type OpenClawConfigService interface {
 
 type openClawConfigService struct {
 	repo          repository.OpenClawConfigRepository
+	skillRepo     repository.SkillRepository
 	secretService *k8s.SecretService
 }
 
@@ -268,9 +294,10 @@ type compiledOpenClawConfig struct {
 	totalPayloadSize int
 }
 
-func NewOpenClawConfigService(repo repository.OpenClawConfigRepository) OpenClawConfigService {
+func NewOpenClawConfigService(repo repository.OpenClawConfigRepository, skillRepo repository.SkillRepository) OpenClawConfigService {
 	return &openClawConfigService{
 		repo:          repo,
+		skillRepo:     skillRepo,
 		secretService: k8s.NewSecretService(),
 	}
 }
@@ -535,6 +562,9 @@ func (s *openClawConfigService) CreateBundle(userID int, req UpsertOpenClawConfi
 	if err := s.repo.ReplaceBundleItems(item.ID, normalizeBundleItems(req.Items)); err != nil {
 		return nil, err
 	}
+	if err := s.repo.ReplaceBundleSkills(item.ID, normalizeBundleSkills(req.SkillItems)); err != nil {
+		return nil, err
+	}
 
 	payload, err := s.bundlePayloadFromModel(*item)
 	if err != nil {
@@ -566,6 +596,9 @@ func (s *openClawConfigService) UpdateBundle(userID, id int, req UpsertOpenClawC
 		return nil, err
 	}
 	if err := s.repo.ReplaceBundleItems(item.ID, normalizeBundleItems(req.Items)); err != nil {
+		return nil, err
+	}
+	if err := s.repo.ReplaceBundleSkills(item.ID, normalizeBundleSkills(req.SkillItems)); err != nil {
 		return nil, err
 	}
 
@@ -600,6 +633,10 @@ func (s *openClawConfigService) CloneBundle(userID, id int) (*OpenClawConfigBund
 	if err != nil {
 		return nil, err
 	}
+	skills, err := s.repo.ListBundleSkills(id)
+	if err != nil {
+		return nil, err
+	}
 
 	clone := *item
 	clone.ID = 0
@@ -617,12 +654,58 @@ func (s *openClawConfigService) CloneBundle(userID, id int) (*OpenClawConfigBund
 	if err := s.repo.ReplaceBundleItems(clone.ID, items); err != nil {
 		return nil, err
 	}
+	for idx := range skills {
+		skills[idx].ID = 0
+		skills[idx].BundleID = clone.ID
+	}
+	if err := s.repo.ReplaceBundleSkills(clone.ID, skills); err != nil {
+		return nil, err
+	}
 
 	payload, err := s.bundlePayloadFromModel(clone)
 	if err != nil {
 		return nil, err
 	}
 	return &payload, nil
+}
+
+func (s *openClawConfigService) ResolveBundleSkillIDs(userID int, plan *OpenClawConfigPlan) ([]int, error) {
+	if plan == nil || plan.Mode != OpenClawConfigPlanModeBundle || plan.BundleID == nil || *plan.BundleID <= 0 {
+		return nil, nil
+	}
+
+	bundle, err := s.repo.GetBundleByID(*plan.BundleID)
+	if err != nil {
+		return nil, err
+	}
+	if bundle == nil || bundle.UserID != userID {
+		return nil, fmt.Errorf("openclaw config bundle not found")
+	}
+	if !bundle.Enabled {
+		return nil, fmt.Errorf("openclaw config bundle is disabled")
+	}
+
+	bundleSkills, err := s.repo.ListBundleSkills(bundle.ID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]int, 0, len(bundleSkills))
+	seen := map[int]struct{}{}
+	for _, item := range bundleSkills {
+		if _, exists := seen[item.SkillID]; exists {
+			continue
+		}
+		skill, err := s.getBundleSkill(userID, item.SkillID)
+		if err != nil {
+			return nil, err
+		}
+		if skill == nil {
+			return nil, fmt.Errorf("skill not found")
+		}
+		seen[item.SkillID] = struct{}{}
+		result = append(result, item.SkillID)
+	}
+	return result, nil
 }
 
 func (s *openClawConfigService) CompilePreview(userID int, plan OpenClawConfigPlan) (*OpenClawConfigCompilePreview, error) {
@@ -861,8 +944,8 @@ func (s *openClawConfigService) validateBundleRequest(userID int, req UpsertOpen
 	if strings.TrimSpace(req.Name) == "" {
 		return fmt.Errorf("openclaw config bundle name is required")
 	}
-	if len(req.Items) == 0 {
-		return fmt.Errorf("openclaw config bundle must include at least one resource")
+	if len(req.Items) == 0 && len(req.SkillItems) == 0 {
+		return fmt.Errorf("openclaw config bundle must include at least one resource or skill")
 	}
 
 	seen := map[int]struct{}{}
@@ -883,7 +966,40 @@ func (s *openClawConfigService) validateBundleRequest(userID int, req UpsertOpen
 			return fmt.Errorf("openclaw config resource not found")
 		}
 	}
+
+	seenSkills := map[int]struct{}{}
+	for _, item := range req.SkillItems {
+		if item.SkillID <= 0 {
+			return fmt.Errorf("openclaw config bundle skill id is required")
+		}
+		if _, exists := seenSkills[item.SkillID]; exists {
+			return fmt.Errorf("openclaw config bundle contains duplicate skills")
+		}
+		seenSkills[item.SkillID] = struct{}{}
+
+		skill, err := s.getBundleSkill(userID, item.SkillID)
+		if err != nil {
+			return err
+		}
+		if skill == nil {
+			return fmt.Errorf("skill not found")
+		}
+	}
 	return nil
+}
+
+func (s *openClawConfigService) getBundleSkill(userID, skillID int) (*models.Skill, error) {
+	if s.skillRepo == nil {
+		return nil, fmt.Errorf("skill repository is not initialized")
+	}
+	skill, err := s.skillRepo.GetSkillByID(skillID)
+	if err != nil {
+		return nil, err
+	}
+	if skill == nil || skill.UserID != userID || !isUserManagedSkill(*skill) || !strings.EqualFold(skill.Status, "active") {
+		return nil, nil
+	}
+	return skill, nil
 }
 
 func normalizeBundleItems(items []OpenClawConfigBundleItemPayload) []models.OpenClawConfigBundleItem {
@@ -902,8 +1018,28 @@ func normalizeBundleItems(items []OpenClawConfigBundleItemPayload) []models.Open
 	return result
 }
 
+func normalizeBundleSkills(items []OpenClawConfigBundleSkillPayload) []models.OpenClawConfigBundleSkill {
+	result := make([]models.OpenClawConfigBundleSkill, 0, len(items))
+	for idx, item := range items {
+		sortOrder := item.SortOrder
+		if sortOrder == 0 {
+			sortOrder = idx + 1
+		}
+		result = append(result, models.OpenClawConfigBundleSkill{
+			SkillID:   item.SkillID,
+			SortOrder: sortOrder,
+			Required:  item.Required,
+		})
+	}
+	return result
+}
+
 func (s *openClawConfigService) bundlePayloadFromModel(item models.OpenClawConfigBundle) (OpenClawConfigBundlePayload, error) {
 	bundleItems, err := s.repo.ListBundleItems(item.ID)
+	if err != nil {
+		return OpenClawConfigBundlePayload{}, err
+	}
+	bundleSkills, err := s.repo.ListBundleSkills(item.ID)
 	if err != nil {
 		return OpenClawConfigBundlePayload{}, err
 	}
@@ -928,6 +1064,26 @@ func (s *openClawConfigService) bundlePayloadFromModel(item models.OpenClawConfi
 		})
 	}
 
+	payloadSkills := make([]OpenClawConfigBundleSkillPayload, 0, len(bundleSkills))
+	for _, bundleSkill := range bundleSkills {
+		var summary *OpenClawConfigBundleSkillSummary
+		skill, err := s.getBundleSkill(item.UserID, bundleSkill.SkillID)
+		if err != nil {
+			return OpenClawConfigBundlePayload{}, err
+		}
+		if skill != nil {
+			skillSummary := bundleSkillSummaryFromModel(*skill)
+			summary = &skillSummary
+		}
+
+		payloadSkills = append(payloadSkills, OpenClawConfigBundleSkillPayload{
+			SkillID:   bundleSkill.SkillID,
+			SortOrder: bundleSkill.SortOrder,
+			Required:  bundleSkill.Required,
+			Skill:     summary,
+		})
+	}
+
 	return OpenClawConfigBundlePayload{
 		ID:          item.ID,
 		UserID:      item.UserID,
@@ -936,6 +1092,7 @@ func (s *openClawConfigService) bundlePayloadFromModel(item models.OpenClawConfi
 		Enabled:     item.Enabled,
 		Version:     item.Version,
 		Items:       payloadItems,
+		SkillItems:  payloadSkills,
 		CreatedAt:   item.CreatedAt,
 		UpdatedAt:   item.UpdatedAt,
 	}, nil
@@ -1081,7 +1238,11 @@ func (s *openClawConfigService) loadSelectedResources(userID int, plan OpenClawC
 		if err != nil {
 			return nil, nil, err
 		}
-		if len(items) == 0 {
+		skills, err := s.repo.ListBundleSkills(bundle.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(items) == 0 && len(skills) == 0 {
 			return nil, nil, fmt.Errorf("openclaw config bundle is empty")
 		}
 
@@ -1196,6 +1357,23 @@ func resourceSummaryFromModel(item models.OpenClawConfigResource) OpenClawConfig
 		Name:         item.Name,
 		Enabled:      item.Enabled,
 		Version:      item.Version,
+	}
+}
+
+func bundleSkillSummaryFromModel(item models.Skill) OpenClawConfigBundleSkillSummary {
+	return OpenClawConfigBundleSkillSummary{
+		ID:               item.ID,
+		UserID:           item.UserID,
+		SkillKey:         item.SkillKey,
+		Name:             item.Name,
+		Description:      item.Description,
+		Status:           item.Status,
+		SourceType:       item.SourceType,
+		RiskLevel:        item.RiskLevel,
+		CurrentVersionID: item.CurrentVersionID,
+		LastScannedAt:    item.LastScannedAt,
+		CreatedAt:        item.CreatedAt,
+		UpdatedAt:        item.UpdatedAt,
 	}
 }
 
@@ -1380,6 +1558,8 @@ func normalizeOpenClawChannelConfigForEnv(resourceKey string, configPayload inte
 		return normalizeSlackChannelConfigForEnv(configPayload)
 	case "telegram":
 		return normalizeTelegramChannelConfigForEnv(configPayload)
+	case "wecom":
+		return normalizeWeComChannelConfigForEnv(configPayload)
 	}
 
 	return configPayload
@@ -1565,6 +1745,32 @@ func normalizeDingTalkChannelConfigForEnv(configPayload interface{}) map[string]
 		"clientId":     clientID,
 		"clientSecret": clientSecret,
 		"allowFrom":    allowFrom,
+	}
+}
+
+func normalizeWeComChannelConfigForEnv(configPayload interface{}) map[string]interface{} {
+	config, ok := configPayload.(map[string]interface{})
+	if !ok {
+		config = map[string]interface{}{}
+	}
+
+	botID, _ := config["botId"].(string)
+	secret, _ := config["secret"].(string)
+	dmPolicy, _ := config["dmPolicy"].(string)
+	if strings.TrimSpace(dmPolicy) == "" {
+		dmPolicy = "pairing"
+	}
+
+	allowFrom := normalizeStringArrayForEnv(config["allowFrom"])
+	if len(allowFrom) == 0 {
+		allowFrom = []string{"*"}
+	}
+
+	return map[string]interface{}{
+		"botId":     botID,
+		"secret":    secret,
+		"dmPolicy":  dmPolicy,
+		"allowFrom": allowFrom,
 	}
 }
 

--- a/backend/internal/services/openclaw_config_service_test.go
+++ b/backend/internal/services/openclaw_config_service_test.go
@@ -79,6 +79,22 @@ func TestRenderCompiledOpenClawPayloadRendersChannelsAsKeyedConfigMap(t *testing
 		},
 		{
 			model: models.OpenClawConfigResource{
+				ID:           6,
+				ResourceType: OpenClawConfigResourceTypeChannel,
+				ResourceKey:  "wecom",
+				Name:         "WeCom",
+				Version:      1,
+				ContentJSON:  `{"schemaVersion":1,"kind":"channel","format":"channel/wecom@v1","dependsOn":[],"config":{"enabled":false,"botId":"ww-bot","secret":"wecom-secret","dmPolicy":"pairing","allowFrom":["*"],"legacyField":"drop-me"}}`,
+			},
+			envelope: OpenClawConfigEnvelope{
+				SchemaVersion: 1,
+				Kind:          "channel",
+				Format:        "channel/wecom@v1",
+				Config:        json.RawMessage(`{"enabled":false,"botId":"ww-bot","secret":"wecom-secret","dmPolicy":"pairing","allowFrom":["*"],"legacyField":"drop-me"}`),
+			},
+		},
+		{
+			model: models.OpenClawConfigResource{
 				ID:           5,
 				ResourceType: OpenClawConfigResourceTypeSkill,
 				ResourceKey:  "support-bot",
@@ -102,7 +118,7 @@ func TestRenderCompiledOpenClawPayloadRendersChannelsAsKeyedConfigMap(t *testing
 	}
 
 	gotChannels := renderedEnv[OpenClawChannelsEnv]
-	wantChannels := `{"dingtalk-connector":{"allowFrom":["*"],"clientId":"ding-xxxxxxxxxxxxxx","clientSecret":"xxxxxxxxxxxxxxxxxxxxxxx","enabled":true},"feishu":{"accounts":{"main":{"appId":"cli_xxx","appSecret":"xxx"}},"enabled":true},"slack":{"appToken":"xapp-xxx","botToken":"xoxb-xxx","capabilities":{"interactiveReplies":true},"channels":{"#general":{"allow":true}},"enabled":true,"groupPolicy":"allowlist"},"telegram":{"allowFrom":["*"],"botToken":"123456:xxx","dmPolicy":"open","enabled":true}}`
+	wantChannels := `{"dingtalk-connector":{"allowFrom":["*"],"clientId":"ding-xxxxxxxxxxxxxx","clientSecret":"xxxxxxxxxxxxxxxxxxxxxxx","enabled":true},"feishu":{"accounts":{"main":{"appId":"cli_xxx","appSecret":"xxx"}},"enabled":true},"slack":{"appToken":"xapp-xxx","botToken":"xoxb-xxx","capabilities":{"interactiveReplies":true},"channels":{"#general":{"allow":true}},"enabled":true,"groupPolicy":"allowlist"},"telegram":{"allowFrom":["*"],"botToken":"123456:xxx","dmPolicy":"open","enabled":true},"wecom":{"allowFrom":["*"],"botId":"ww-bot","dmPolicy":"pairing","secret":"wecom-secret"}}`
 	if gotChannels != wantChannels {
 		t.Fatalf("unexpected channel payload:\nwant: %s\ngot:  %s", wantChannels, gotChannels)
 	}
@@ -200,6 +216,44 @@ func TestResourcePayloadFromModelNormalizesStoredDingTalkChannelJSON(t *testing.
 
 	got := string(payload.Content)
 	want := `{"schemaVersion":1,"kind":"channel","format":"channel/dingtalk-connector@v1","dependsOn":[],"config":{"enabled":true,"clientId":"ding-xxxxxxxxxxxxxx","clientSecret":"xxxxxxxxxxxxxxxxxxxxxxx","allowFrom":["*"],"legacyField":"drop-me"}}`
+
+	var gotJSON interface{}
+	if err := json.Unmarshal([]byte(got), &gotJSON); err != nil {
+		t.Fatalf("failed to unmarshal normalized resource content: %v", err)
+	}
+
+	var wantJSON interface{}
+	if err := json.Unmarshal([]byte(want), &wantJSON); err != nil {
+		t.Fatalf("failed to unmarshal expected normalized resource content: %v", err)
+	}
+
+	if !reflect.DeepEqual(gotJSON, wantJSON) {
+		t.Fatalf("unexpected normalized resource content:\nwant: %s\ngot:  %s", want, got)
+	}
+}
+
+func TestResourcePayloadFromModelNormalizesStoredWeComChannelJSON(t *testing.T) {
+	t.Parallel()
+
+	item := models.OpenClawConfigResource{
+		ID:           12,
+		UserID:       1,
+		ResourceType: OpenClawConfigResourceTypeChannel,
+		ResourceKey:  "wecom",
+		Name:         "WeCom",
+		Enabled:      true,
+		Version:      1,
+		TagsJSON:     `["channel","builtin","wecom"]`,
+		ContentJSON:  `{"schemaVersion":1,"kind":"channel","format":"channel/wecom@v1","dependsOn":[],"config":{"enabled":false,"botId":"ww-bot","secret":"wecom-secret","allowFrom":[],"legacyField":"keep-me"}}`,
+	}
+
+	payload, err := resourcePayloadFromModel(item)
+	if err != nil {
+		t.Fatalf("resourcePayloadFromModel returned error: %v", err)
+	}
+
+	got := string(payload.Content)
+	want := `{"schemaVersion":1,"kind":"channel","format":"channel/wecom@v1","dependsOn":[],"config":{"enabled":false,"botId":"ww-bot","secret":"wecom-secret","allowFrom":["*"],"legacyField":"keep-me","dmPolicy":"pairing"}}`
 
 	var gotJSON interface{}
 	if err := json.Unmarshal([]byte(got), &gotJSON); err != nil {
@@ -418,6 +472,15 @@ func TestNormalizeOpenClawResourceContentPreservesUnknownChannelFields(t *testin
 			wantKeep: map[string]interface{}{
 				"allowFrom": []interface{}{"C123", "C456"},
 				"dmPolicy":  "closed",
+			},
+		},
+		{
+			name:        "wecom preserves webhook and custom capabilities",
+			resourceKey: "wecom",
+			content:     `{"schemaVersion":1,"kind":"channel","format":"channel/wecom@v1","dependsOn":[],"config":{"enabled":true,"botId":"ww-bot","secret":"sec","dmPolicy":"pairing","allowFrom":[],"webhook":"https://example.com/wecom","capabilities":{"interactiveReplies":true}}}`,
+			wantKeep: map[string]interface{}{
+				"webhook":      "https://example.com/wecom",
+				"capabilities": map[string]interface{}{"interactiveReplies": true},
 			},
 		},
 	}

--- a/backend/internal/services/team_service.go
+++ b/backend/internal/services/team_service.go
@@ -45,6 +45,8 @@ type TeamService interface {
 	CreateTeam(userID int, req CreateTeamRequest) (*TeamDetailsPayload, error)
 	ListTeams(userID, offset, limit int) (*TeamListPayload, error)
 	GetTeam(userID, teamID int) (*TeamDetailsPayload, error)
+	ListTeamTasks(userID, teamID, beforeID, limit int) (*TeamTasksHistoryPayload, error)
+	ListTeamEvents(userID, teamID, beforeID, limit int) (*TeamEventsHistoryPayload, error)
 	DispatchTask(userID, teamID int, req DispatchTeamTaskRequest) (*TeamTaskPayload, error)
 	DeleteTeam(userID, teamID int) error
 	DeleteMember(userID, teamID int, memberID string) error
@@ -96,6 +98,18 @@ type TeamDetailsPayload struct {
 	Members        []models.TeamMember `json:"members"`
 	Tasks          []TeamTaskPayload   `json:"tasks,omitempty"`
 	Events         []TeamEventPayload  `json:"events,omitempty"`
+}
+
+type TeamTasksHistoryPayload struct {
+	Tasks        []TeamTaskPayload `json:"tasks"`
+	HasMore      bool              `json:"has_more"`
+	NextBeforeID *int              `json:"next_before_id,omitempty"`
+}
+
+type TeamEventsHistoryPayload struct {
+	Events       []TeamEventPayload `json:"events"`
+	HasMore      bool               `json:"has_more"`
+	NextBeforeID *int               `json:"next_before_id,omitempty"`
 }
 
 type TeamTaskPayload struct {
@@ -517,6 +531,48 @@ func (s *teamService) GetTeam(userID, teamID int) (*TeamDetailsPayload, error) {
 		Members:        members,
 		Tasks:          teamTaskPayloads(tasks),
 		Events:         teamEventPayloads(events),
+	}, nil
+}
+
+func (s *teamService) ListTeamTasks(userID, teamID, beforeID, limit int) (*TeamTasksHistoryPayload, error) {
+	if _, err := s.requireOwnedTeam(userID, teamID); err != nil {
+		return nil, err
+	}
+	limit = normalizeTeamHistoryLimit(limit, 20, 100)
+	tasks, err := s.repo.ListTasksBeforeID(teamID, beforeID, limit+1)
+	if err != nil {
+		return nil, err
+	}
+	hasMore := len(tasks) > limit
+	if hasMore {
+		tasks = tasks[:limit]
+	}
+	payload := teamTaskPayloads(tasks)
+	return &TeamTasksHistoryPayload{
+		Tasks:        payload,
+		HasMore:      hasMore,
+		NextBeforeID: nextTeamTaskBeforeID(payload),
+	}, nil
+}
+
+func (s *teamService) ListTeamEvents(userID, teamID, beforeID, limit int) (*TeamEventsHistoryPayload, error) {
+	if _, err := s.requireOwnedTeam(userID, teamID); err != nil {
+		return nil, err
+	}
+	limit = normalizeTeamHistoryLimit(limit, 50, 200)
+	events, err := s.repo.ListEventsBeforeID(teamID, beforeID, limit+1)
+	if err != nil {
+		return nil, err
+	}
+	hasMore := len(events) > limit
+	if hasMore {
+		events = events[:limit]
+	}
+	payload := teamEventPayloads(events)
+	return &TeamEventsHistoryPayload{
+		Events:       payload,
+		HasMore:      hasMore,
+		NextBeforeID: nextTeamEventBeforeID(payload),
 	}, nil
 }
 
@@ -1272,6 +1328,32 @@ func teamTaskPayloads(tasks []models.TeamTask) []TeamTaskPayload {
 		}
 	}
 	return result
+}
+
+func normalizeTeamHistoryLimit(limit, defaultLimit, maxLimit int) int {
+	if limit <= 0 {
+		return defaultLimit
+	}
+	if limit > maxLimit {
+		return maxLimit
+	}
+	return limit
+}
+
+func nextTeamTaskBeforeID(tasks []TeamTaskPayload) *int {
+	if len(tasks) == 0 {
+		return nil
+	}
+	next := tasks[len(tasks)-1].ID
+	return &next
+}
+
+func nextTeamEventBeforeID(events []TeamEventPayload) *int {
+	if len(events) == 0 {
+		return nil
+	}
+	next := events[len(events)-1].ID
+	return &next
 }
 
 func teamTaskPayload(task models.TeamTask) (*TeamTaskPayload, error) {

--- a/deployments/container/start.sh
+++ b/deployments/container/start.sh
@@ -27,6 +27,16 @@ fi
 
 export SERVER_ADDRESS="${SERVER_ADDRESS:-:9001}"
 export SERVER_MODE="${SERVER_MODE:-release}"
+export CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB="${CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB:-500}"
+
+case "${CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB}" in
+  ''|*[!0-9]*|0)
+    echo "Invalid CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB=${CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB}; falling back to 500 MiB."
+    export CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB="500"
+    ;;
+esac
+
+sed -i "s/client_max_body_size [0-9][0-9]*m;/client_max_body_size ${CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB}m;/" /etc/nginx/nginx.conf
 
 /usr/local/bin/clawreef-server &
 backend_pid=$!

--- a/deployments/k3s/clawmanager.yaml
+++ b/deployments/k3s/clawmanager.yaml
@@ -650,6 +650,20 @@ data:
       WHERE instance_type = 'openclaw'
         AND is_enabled = FALSE
     );
+  022_add_openclaw_config_bundle_skills.sql: |
+    USE clawmanager;
+    CREATE TABLE IF NOT EXISTS openclaw_config_bundle_skills (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      bundle_id INT NOT NULL,
+      skill_id INT NOT NULL,
+      sort_order INT NOT NULL DEFAULT 0,
+      required BOOLEAN NOT NULL DEFAULT TRUE,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (bundle_id) REFERENCES openclaw_config_bundles(id) ON DELETE CASCADE,
+      FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE,
+      UNIQUE KEY uk_openclaw_bundle_skill (bundle_id, skill_id),
+      INDEX idx_openclaw_bundle_skill_bundle (bundle_id, sort_order)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -855,6 +869,8 @@ spec:
               value: "clawmanager"
             - name: K8S_STORAGE_CLASS
               value: "local-path"
+            - name: CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB
+              value: "500"
             - name: CLAWMANAGER_TEAM_REDIS_URL
               value: "redis://clawmanager-team-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: CLAWMANAGER_TEAM_MANAGER_BASE_URL

--- a/deployments/k8s/clawmanager.yaml
+++ b/deployments/k8s/clawmanager.yaml
@@ -654,6 +654,20 @@ data:
       WHERE instance_type = 'openclaw'
         AND is_enabled = FALSE
     );
+  022_add_openclaw_config_bundle_skills.sql: |
+    USE clawmanager;
+    CREATE TABLE IF NOT EXISTS openclaw_config_bundle_skills (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      bundle_id INT NOT NULL,
+      skill_id INT NOT NULL,
+      sort_order INT NOT NULL DEFAULT 0,
+      required BOOLEAN NOT NULL DEFAULT TRUE,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (bundle_id) REFERENCES openclaw_config_bundles(id) ON DELETE CASCADE,
+      FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE,
+      UNIQUE KEY uk_openclaw_bundle_skill (bundle_id, skill_id),
+      INDEX idx_openclaw_bundle_skill_bundle (bundle_id, sort_order)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -1054,6 +1068,8 @@ spec:
               value: "manual"
             - name: K8S_PV_HOST_PATH_PREFIX
               value: "/data/clawreef"
+            - name: CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB
+              value: "500"
             - name: CLAWMANAGER_TEAM_REDIS_URL
               value: "redis://clawmanager-team-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: CLAWMANAGER_TEAM_MANAGER_BASE_URL

--- a/deployments/nginx/nginx.conf
+++ b/deployments/nginx/nginx.conf
@@ -40,11 +40,12 @@ http {
         root /usr/share/nginx/html;
         index index.html;
 
-        # Allow OpenClaw workspace archives through the API.
+        # Allow runtime workspace archives through the API.
         # Default nginx client_max_body_size (1 MiB) would reject normal
-        # .openclaw uploads at the edge with 413 Content Too Large before
-        # the request reaches the backend.
-        client_max_body_size 50m;
+        # workspace uploads at the edge with 413 Content Too Large before
+        # the request reaches the backend. start.sh rewrites this value from
+        # CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB when set.
+        client_max_body_size 500m;
 
         location = /healthz {
             access_log off;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,6 +38,7 @@ Choose the deployment path that matches your environment:
 
 - ClawManager is designed around in-cluster services and platform-mediated access rather than direct pod exposure.
 - Resource Management features depend on object storage and `skill-scanner` being available.
+- Runtime workspace `.openclaw` and `.hermes` archive import/export size is controlled by `CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB`. The default is `500` MiB; set the env var on the ClawManager app deployment when a larger or smaller limit is needed.
 - Production environments should review images, credentials, TLS, persistence, and networking policies before rollout.
 
 ## Related Guides

--- a/docs/resource-management.md
+++ b/docs/resource-management.md
@@ -5,14 +5,15 @@ Resource Management is the reusable asset layer for OpenClaw workspaces in ClawM
 ## Main Resource Types
 
 - `Channels` for workspace connectivity and integration templates
-- `Skills` for reusable packaged capabilities
-- `Bundles` for composing repeatable resource sets
+- `Skills` for reusable uploaded packages that can be installed into runtime instances
+- Config skills for bootstrap configuration delivered through runtime environment payloads
+- `Bundles` for composing repeatable resource sets, including both config resources and uploaded skills
 - injection snapshots for tracking the compiled result applied to an instance
 
 ## Core Workflows
 
 1. Create or import channels and skills in the OpenClaw Config Center.
-2. Organize selected resources into reusable bundles.
+2. Organize selected config resources and uploaded skills into reusable bundles.
 3. Review scan posture for skills through Security Center.
 4. Apply resources or bundles to OpenClaw workspaces.
 5. Inspect runtime state and instance-level resource results after injection.
@@ -20,6 +21,7 @@ Resource Management is the reusable asset layer for OpenClaw workspaces in ClawM
 ## How It Connects to the Platform
 
 - Resource Management defines what should be delivered to a workspace.
+- Config resources are compiled into bootstrap environment payloads. Uploaded skills in a bundle are installed through the Agent Control Plane skill installation path.
 - Agent Control Plane applies and tracks those changes at runtime.
 - Security Center and `skill-scanner` help review the risk posture of reusable skills before broad rollout.
 

--- a/frontend/src/components/OpenClawConfigPlanSection.tsx
+++ b/frontend/src/components/OpenClawConfigPlanSection.tsx
@@ -199,7 +199,7 @@ const OpenClawConfigPlanSection: React.FC<OpenClawConfigPlanSectionProps> = ({
               <option key={bundle.id} value={bundle.id}>
                 {bundle.name} (
                 {t("openClawInjectionSection.bundleOptionCount", {
-                  count: bundle.items.length,
+                  count: bundle.items.length + (bundle.skill_items?.length || 0),
                 })}
                 )
               </option>

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1703,10 +1703,10 @@ export const translations: Record<Locale, TranslationTree> = {
       workspaceSection: "Workspace",
       openClawWorkspace: "OpenClaw Workspace",
       openClawWorkspaceDesc:
-        "Import or export the `.openclaw` folder as a `.tar.gz` archive up to 50 MiB.",
+        "Import or export the `.openclaw` folder as a `.tar.gz` archive up to 500 MiB by default.",
       runtimeWorkspace: "{runtime} Workspace",
       runtimeWorkspaceDesc:
-        "Import or export the `{directory}` folder as a `.tar.gz` archive up to 50 MiB.",
+        "Import or export the `{directory}` folder as a `.tar.gz` archive up to 500 MiB by default.",
       workspaceReady: "Ready",
       workspacePaused: "Paused",
       exportingOpenClaw: "Exporting...",
@@ -1720,7 +1720,7 @@ export const translations: Record<Locale, TranslationTree> = {
       importRuntimeWorkspace: "Import {directory}",
       importRuntimeWorkspaceSuccess:
         "{runtime} workspace imported successfully.",
-      openClawArchiveTooLarge: "Archive too large. Maximum size is 50 MiB.",
+      openClawArchiveTooLarge: "Archive too large. Maximum size is 500 MiB by default.",
       importOpenClawFailed: "Failed to import .openclaw: {message}",
       exportOpenClawFailed: "Failed to export .openclaw: {message}",
       importRuntimeWorkspaceFailed:
@@ -2068,6 +2068,8 @@ export const translations: Record<Locale, TranslationTree> = {
         "Compose a new reusable bundle without leaving the resources list behind.",
       bundleName: "Bundle Name",
       bundleResources: "Bundle Resources",
+      uploadedSkills: "Uploaded Skills",
+      noUploadedSkillsForBundle: "No active low-risk uploaded skills yet.",
       noResourcesForGroup: "No {type} resources yet.",
       actions: {
         new: "New",
@@ -2103,6 +2105,11 @@ export const translations: Record<Locale, TranslationTree> = {
           description:
             "DingTalk channel with client credentials and sender allowlist controls.",
         },
+        wecom: {
+          label: "WeCom",
+          description:
+            "WeCom channel with bot credentials and pairing DM controls.",
+        },
         slack: {
           label: "Slack",
           description: "Slack workspace app powered by Bolt.",
@@ -2130,6 +2137,21 @@ export const translations: Record<Locale, TranslationTree> = {
             clientSecret: {
               label: "Client Secret",
               placeholder: "client secret",
+            },
+          },
+        },
+        wecom: {
+          title: "WeCom Channel Editor",
+          description:
+            "Start with the bot credential form, or switch to JSON when you need the full config surface.",
+          fields: {
+            botId: {
+              label: "Bot ID",
+              placeholder: "xxxxxxx",
+            },
+            secret: {
+              label: "Secret",
+              placeholder: "bot secret",
             },
           },
         },
@@ -2910,10 +2932,10 @@ export const translations: Record<Locale, TranslationTree> = {
       workspaceSection: "工作区",
       openClawWorkspace: "OpenClaw 工作区",
       openClawWorkspaceDesc:
-        "可将 `.openclaw` 文件夹导入或导出为不超过 50 MiB 的 `.tar.gz` 压缩包。",
+        "默认可将 `.openclaw` 文件夹导入或导出为不超过 500 MiB 的 `.tar.gz` 压缩包。",
       runtimeWorkspace: "{runtime} 工作区",
       runtimeWorkspaceDesc:
-        "可将 `{directory}` 文件夹导入或导出为不超过 50 MiB 的 `.tar.gz` 压缩包。",
+        "默认可将 `{directory}` 文件夹导入或导出为不超过 500 MiB 的 `.tar.gz` 压缩包。",
       workspaceReady: "可操作",
       workspacePaused: "未就绪",
       exportingOpenClaw: "正在导出...",
@@ -2925,7 +2947,7 @@ export const translations: Record<Locale, TranslationTree> = {
       importingRuntimeWorkspace: "正在导入...",
       importRuntimeWorkspace: "导入 {directory}",
       importRuntimeWorkspaceSuccess: "{runtime} 工作区导入成功。",
-      openClawArchiveTooLarge: "归档过大。最大大小为 50 MiB。",
+      openClawArchiveTooLarge: "归档过大。默认最大大小为 500 MiB。",
       importRuntimeWorkspaceFailed: "导入 {directory} 失败：{message}",
       exportRuntimeWorkspaceFailed: "导出 {directory} 失败：{message}",
       memoryReserved: "预留内存",
@@ -3245,6 +3267,8 @@ export const translations: Record<Locale, TranslationTree> = {
       newBundleSubtitle: "无需离开资源列表，就能创建新的可复用资源包。",
       bundleName: "资源包名称",
       bundleResources: "资源包内容",
+      uploadedSkills: "已上传技能",
+      noUploadedSkillsForBundle: "当前还没有可加入资源包的低风险已上传技能。",
       noResourcesForGroup: "当前还没有 {type} 资源。",
       actions: {
         new: "新建",
@@ -3278,6 +3302,10 @@ export const translations: Record<Locale, TranslationTree> = {
           label: "DingTalk",
           description: "支持客户端凭证和发送方白名单控制的 DingTalk 通道。",
         },
+        wecom: {
+          label: "企业微信",
+          description: "支持 Bot ID、Secret 和私聊配对策略的企业微信通道。",
+        },
         slack: {
           label: "Slack",
           description: "基于 Bolt 的 Slack 工作区应用通道。",
@@ -3304,6 +3332,20 @@ export const translations: Record<Locale, TranslationTree> = {
             clientSecret: {
               label: "Client Secret",
               placeholder: "客户端密钥",
+            },
+          },
+        },
+        wecom: {
+          title: "企业微信 Channel 编辑器",
+          description: "先填写 Bot 凭证表单，只有在需要完整配置时再切到 JSON。",
+          fields: {
+            botId: {
+              label: "Bot ID",
+              placeholder: "xxxxxxx",
+            },
+            secret: {
+              label: "Secret",
+              placeholder: "机器人密钥",
             },
           },
         },
@@ -4122,10 +4164,10 @@ export const translations: Record<Locale, TranslationTree> = {
       workspaceSection: "ワークスペース",
       openClawWorkspace: "OpenClaw ワークスペース",
       openClawWorkspaceDesc:
-        "`.openclaw` フォルダーを 50 MiB までの `.tar.gz` アーカイブとしてインポートまたはエクスポートできます。",
+        "`.openclaw` フォルダーを既定で 500 MiB までの `.tar.gz` アーカイブとしてインポートまたはエクスポートできます。",
       runtimeWorkspace: "{runtime} ワークスペース",
       runtimeWorkspaceDesc:
-        "`{directory}` フォルダーを 50 MiB までの `.tar.gz` アーカイブとしてインポートまたはエクスポートできます。",
+        "`{directory}` フォルダーを既定で 500 MiB までの `.tar.gz` アーカイブとしてインポートまたはエクスポートできます。",
       workspaceReady: "利用可能",
       workspacePaused: "停止中",
       exportingOpenClaw: "エクスポート中...",
@@ -4139,7 +4181,7 @@ export const translations: Record<Locale, TranslationTree> = {
       importRuntimeWorkspace: "{directory} をインポート",
       importRuntimeWorkspaceSuccess:
         "{runtime} ワークスペースをインポートしました。",
-      openClawArchiveTooLarge: "アーカイブが大きすぎます。最大サイズは 50 MiB です。",
+      openClawArchiveTooLarge: "アーカイブが大きすぎます。既定の最大サイズは 500 MiB です。",
       importOpenClawFailed: ".openclaw のインポートに失敗しました: {message}",
       exportOpenClawFailed: ".openclaw のエクスポートに失敗しました: {message}",
       importRuntimeWorkspaceFailed:
@@ -4492,6 +4534,9 @@ export const translations: Record<Locale, TranslationTree> = {
         "リソース一覧を離れずに新しい再利用可能バンドルを作成します。",
       bundleName: "バンドル名",
       bundleResources: "バンドルのリソース",
+      uploadedSkills: "アップロード済みスキル",
+      noUploadedSkillsForBundle:
+        "バンドルに追加できる低リスクのアップロード済みスキルはまだありません。",
       noResourcesForGroup: "{type} のリソースはまだありません。",
       actions: {
         new: "新規作成",
@@ -4527,6 +4572,11 @@ export const translations: Record<Locale, TranslationTree> = {
           description:
             "クライアント認証情報と送信元許可リストを設定できる DingTalk チャネル。",
         },
+        wecom: {
+          label: "WeCom",
+          description:
+            "Bot 認証情報とペアリング DM 制御を備えた WeCom チャネル。",
+        },
         slack: {
           label: "Slack",
           description: "Bolt ベースの Slack ワークスペースアプリ。",
@@ -4553,6 +4603,21 @@ export const translations: Record<Locale, TranslationTree> = {
             clientSecret: {
               label: "Client Secret",
               placeholder: "client secret",
+            },
+          },
+        },
+        wecom: {
+          title: "WeCom Channel エディタ",
+          description:
+            "まず Bot 認証情報フォームから始め、完全な設定が必要なときだけ JSON に切り替えます。",
+          fields: {
+            botId: {
+              label: "Bot ID",
+              placeholder: "xxxxxxx",
+            },
+            secret: {
+              label: "Secret",
+              placeholder: "bot secret",
             },
           },
         },
@@ -5360,10 +5425,10 @@ export const translations: Record<Locale, TranslationTree> = {
       workspaceSection: "워크스페이스",
       openClawWorkspace: "OpenClaw 워크스페이스",
       openClawWorkspaceDesc:
-        "`.openclaw` 폴더를 최대 50 MiB 크기의 `.tar.gz` 아카이브로 가져오거나 내보낼 수 있습니다.",
+        "기본적으로 `.openclaw` 폴더를 최대 500 MiB 크기의 `.tar.gz` 아카이브로 가져오거나 내보낼 수 있습니다.",
       runtimeWorkspace: "{runtime} 워크스페이스",
       runtimeWorkspaceDesc:
-        "`{directory}` 폴더를 최대 50 MiB 크기의 `.tar.gz` 아카이브로 가져오거나 내보낼 수 있습니다.",
+        "기본적으로 `{directory}` 폴더를 최대 500 MiB 크기의 `.tar.gz` 아카이브로 가져오거나 내보낼 수 있습니다.",
       workspaceReady: "준비됨",
       workspacePaused: "대기 중",
       exportingOpenClaw: "내보내는 중...",
@@ -5377,7 +5442,7 @@ export const translations: Record<Locale, TranslationTree> = {
       importRuntimeWorkspace: "{directory} 가져오기",
       importRuntimeWorkspaceSuccess:
         "{runtime} 워크스페이스를 가져왔습니다.",
-      openClawArchiveTooLarge: "아카이브가 너무 큽니다. 최대 크기는 50 MiB입니다.",
+      openClawArchiveTooLarge: "아카이브가 너무 큽니다. 기본 최대 크기는 500 MiB입니다.",
       importOpenClawFailed: ".openclaw 가져오기 실패: {message}",
       exportOpenClawFailed: ".openclaw 내보내기 실패: {message}",
       importRuntimeWorkspaceFailed: "{directory} 가져오기 실패: {message}",
@@ -5724,6 +5789,9 @@ export const translations: Record<Locale, TranslationTree> = {
         "리소스 목록을 벗어나지 않고 새 재사용 번들을 만듭니다.",
       bundleName: "번들 이름",
       bundleResources: "번들 리소스",
+      uploadedSkills: "업로드된 스킬",
+      noUploadedSkillsForBundle:
+        "번들에 추가할 수 있는 저위험 업로드 스킬이 아직 없습니다.",
       noResourcesForGroup: "{type} 리소스가 아직 없습니다.",
       actions: {
         new: "새로 만들기",
@@ -5759,6 +5827,11 @@ export const translations: Record<Locale, TranslationTree> = {
           description:
             "클라이언트 자격 증명과 발신자 허용 목록을 지원하는 DingTalk 채널입니다.",
         },
+        wecom: {
+          label: "WeCom",
+          description:
+            "Bot 자격 증명과 페어링 DM 제어를 지원하는 WeCom 채널입니다.",
+        },
         slack: {
           label: "Slack",
           description: "Bolt 기반의 Slack 워크스페이스 앱입니다.",
@@ -5785,6 +5858,21 @@ export const translations: Record<Locale, TranslationTree> = {
             clientSecret: {
               label: "Client Secret",
               placeholder: "client secret",
+            },
+          },
+        },
+        wecom: {
+          title: "WeCom Channel 편집기",
+          description:
+            "먼저 Bot 자격 증명 폼으로 시작하고, 전체 설정이 필요할 때만 JSON 으로 전환하세요.",
+          fields: {
+            botId: {
+              label: "Bot ID",
+              placeholder: "xxxxxxx",
+            },
+            secret: {
+              label: "Secret",
+              placeholder: "bot secret",
             },
           },
         },
@@ -6613,10 +6701,10 @@ export const translations: Record<Locale, TranslationTree> = {
       workspaceSection: "Arbeitsbereich",
       openClawWorkspace: "OpenClaw-Arbeitsbereich",
       openClawWorkspaceDesc:
-        "Importieren oder exportieren Sie den Ordner `.openclaw` als `.tar.gz`-Archiv bis 50 MiB.",
+        "Importieren oder exportieren Sie den Ordner `.openclaw` standardmaessig als `.tar.gz`-Archiv bis 500 MiB.",
       runtimeWorkspace: "{runtime}-Arbeitsbereich",
       runtimeWorkspaceDesc:
-        "Importieren oder exportieren Sie den Ordner `{directory}` als `.tar.gz`-Archiv bis 50 MiB.",
+        "Importieren oder exportieren Sie den Ordner `{directory}` standardmaessig als `.tar.gz`-Archiv bis 500 MiB.",
       workspaceReady: "Bereit",
       workspacePaused: "Pausiert",
       exportingOpenClaw: "Export wird erstellt...",
@@ -6630,7 +6718,7 @@ export const translations: Record<Locale, TranslationTree> = {
       importRuntimeWorkspace: "{directory} importieren",
       importRuntimeWorkspaceSuccess:
         "{runtime}-Arbeitsbereich erfolgreich importiert.",
-      openClawArchiveTooLarge: "Archiv zu groß. Die maximale Größe beträgt 50 MiB.",
+      openClawArchiveTooLarge: "Archiv zu gross. Die Standard-Maximalgroesse betraegt 500 MiB.",
       importOpenClawFailed: ".openclaw-Import fehlgeschlagen: {message}",
       exportOpenClawFailed: ".openclaw-Export fehlgeschlagen: {message}",
       importRuntimeWorkspaceFailed:
@@ -6987,6 +7075,9 @@ export const translations: Record<Locale, TranslationTree> = {
         "Erstellen Sie ein neues wiederverwendbares Bundle, ohne die Ressourcenliste zu verlassen.",
       bundleName: "Bundle-Name",
       bundleResources: "Bundle-Ressourcen",
+      uploadedSkills: "Hochgeladene Skills",
+      noUploadedSkillsForBundle:
+        "Es gibt noch keine aktiven hochgeladenen Skills mit niedrigem Risiko.",
       noResourcesForGroup: "Es gibt noch keine {type}-Ressourcen.",
       actions: {
         new: "Neu",
@@ -7022,6 +7113,11 @@ export const translations: Record<Locale, TranslationTree> = {
           description:
             "DingTalk-Channel mit Client-Zugangsdaten und Absender-Allowlist-Steuerung.",
         },
+        wecom: {
+          label: "WeCom",
+          description:
+            "WeCom-Channel mit Bot-Zugangsdaten und Pairing-Steuerung fuer Direktnachrichten.",
+        },
         slack: {
           label: "Slack",
           description: "Slack-Workspace-App auf Basis von Bolt.",
@@ -7049,6 +7145,21 @@ export const translations: Record<Locale, TranslationTree> = {
             clientSecret: {
               label: "Client Secret",
               placeholder: "client secret",
+            },
+          },
+        },
+        wecom: {
+          title: "WeCom-Channel-Editor",
+          description:
+            "Beginnen Sie mit dem Formular für Bot-Zugangsdaten und wechseln Sie nur bei Bedarf zur vollständigen JSON-Konfiguration.",
+          fields: {
+            botId: {
+              label: "Bot ID",
+              placeholder: "xxxxxxx",
+            },
+            secret: {
+              label: "Secret",
+              placeholder: "bot secret",
             },
           },
         },

--- a/frontend/src/lib/openclawChannelTemplates.ts
+++ b/frontend/src/lib/openclawChannelTemplates.ts
@@ -43,6 +43,12 @@ export const OPENCLAW_CHANNEL_TEMPLATES: OpenClawChannelTemplate[] = [
     clientSecret: '',
     allowFrom: ['*'],
   }),
+  createChannelTemplate('wecom', 'WeCom', 'WeCom channel with bot credentials and pairing DM controls.', 'builtin', {
+    botId: '',
+    secret: '',
+    dmPolicy: 'pairing',
+    allowFrom: ['*'],
+  }),
   createChannelTemplate('slack', 'Slack', 'Slack workspace app powered by Bolt.', 'builtin', {
     enabled: true,
     appToken: '',

--- a/frontend/src/pages/openclaw/OpenClawConfigCenterPage.tsx
+++ b/frontend/src/pages/openclaw/OpenClawConfigCenterPage.tsx
@@ -11,6 +11,7 @@ import { skillService } from "../../services/skillService";
 import type {
   OpenClawConfigBundle,
   OpenClawConfigBundleItem,
+  OpenClawConfigBundleSkillItem,
   OpenClawConfigMode,
   OpenClawConfigResource,
   OpenClawInjectionSnapshot,
@@ -63,6 +64,7 @@ const CHANNEL_TEMPLATE_LABEL_I18N_KEYS: Record<string, string> = {
   telegram: "openClawResourcesPage.templates.telegram.label",
   "dingtalk-connector":
     "openClawResourcesPage.templates.dingtalkConnector.label",
+  wecom: "openClawResourcesPage.templates.wecom.label",
   slack: "openClawResourcesPage.templates.slack.label",
   feishu: "openClawResourcesPage.templates.feishu.label",
 };
@@ -71,6 +73,7 @@ const CHANNEL_TEMPLATE_DESCRIPTION_I18N_KEYS: Record<string, string> = {
   telegram: "openClawResourcesPage.templates.telegram.description",
   "dingtalk-connector":
     "openClawResourcesPage.templates.dingtalkConnector.description",
+  wecom: "openClawResourcesPage.templates.wecom.description",
   slack: "openClawResourcesPage.templates.slack.description",
   feishu: "openClawResourcesPage.templates.feishu.description",
 };
@@ -151,6 +154,7 @@ const newBundleForm = () => ({
   description: "",
   enabled: true,
   itemIds: [] as number[],
+  skillIds: [] as number[],
 });
 
 const splitTagText = (value: string): string[] =>
@@ -168,7 +172,8 @@ type SupportedChannelEditorId =
   | "dingtalk-connector"
   | "feishu"
   | "slack"
-  | "telegram";
+  | "telegram"
+  | "wecom";
 
 interface SupportedChannelEditorField {
   key: string;
@@ -306,6 +311,53 @@ const updateTelegramChannelContentText = (
         ? parsed.dmPolicy
         : "open",
     allowFrom: readStringArray(parsed.allowFrom) || ["*"],
+  };
+
+  return stringifyChannelContentText(mergeChannelConfig(parsed, allowlisted));
+};
+
+const readWeComChannelFormState = (
+  contentText: string,
+): Record<string, string> | null => {
+  const config = parseChannelContentText(contentText);
+  if (!config) {
+    return null;
+  }
+
+  return {
+    botId: typeof config.botId === "string" ? config.botId : "",
+    secret: typeof config.secret === "string" ? config.secret : "",
+  };
+};
+
+const updateWeComChannelContentText = (
+  contentText: string,
+  patch: Record<string, string>,
+): string => {
+  const parsed = parseChannelContentText(contentText);
+  if (!parsed) {
+    return contentText;
+  }
+
+  const currentForm = readWeComChannelFormState(contentText);
+  if (!currentForm) {
+    return contentText;
+  }
+
+  const nextForm = {
+    ...currentForm,
+    ...patch,
+  };
+
+  const allowFrom = readStringArray(parsed.allowFrom);
+  const allowlisted = {
+    botId: nextForm.botId,
+    secret: nextForm.secret,
+    dmPolicy:
+      typeof parsed.dmPolicy === "string" && parsed.dmPolicy
+        ? parsed.dmPolicy
+        : "pairing",
+    allowFrom: allowFrom && allowFrom.length > 0 ? allowFrom : ["*"],
   };
 
   return stringifyChannelContentText(mergeChannelConfig(parsed, allowlisted));
@@ -498,9 +550,14 @@ const detectSupportedChannelEditor = (
   const hasClientSecret = config && typeof config.clientSecret === "string";
   const hasAppToken = config && typeof config.appToken === "string";
   const hasBotToken = config && typeof config.botToken === "string";
+  const hasBotId = config && typeof config.botId === "string";
+  const hasSecret = config && typeof config.secret === "string";
 
   if (normalizedResourceKey === "feishu" || domain === "feishu" || !!accounts) {
     return "feishu";
+  }
+  if (normalizedResourceKey === "wecom" || (hasBotId && hasSecret)) {
+    return "wecom";
   }
   if (
     normalizedResourceKey === "dingtalk-connector" ||
@@ -562,6 +619,12 @@ const normalizeResourceContentTextForEditor = (
       ? updateTelegramChannelContentText(normalizedContentText, currentForm)
       : normalizedContentText;
   }
+  if (editorId === "wecom") {
+    const currentForm = readWeComChannelFormState(normalizedContentText);
+    return currentForm
+      ? updateWeComChannelContentText(normalizedContentText, currentForm)
+      : normalizedContentText;
+  }
 
   return normalizedContentText;
 };
@@ -593,6 +656,28 @@ const SUPPORTED_CHANNEL_EDITORS: Record<
     ],
     readFormState: readDingTalkChannelFormState,
     updateContentText: updateDingTalkChannelContentText,
+  },
+  wecom: {
+    id: "wecom",
+    titleKey: "openClawResourcesPage.channelEditors.wecom.title",
+    descriptionKey: "openClawResourcesPage.channelEditors.wecom.description",
+    fields: [
+      {
+        key: "botId",
+        labelKey: "openClawResourcesPage.channelEditors.wecom.fields.botId.label",
+        placeholderKey:
+          "openClawResourcesPage.channelEditors.wecom.fields.botId.placeholder",
+      },
+      {
+        key: "secret",
+        labelKey:
+          "openClawResourcesPage.channelEditors.wecom.fields.secret.label",
+        placeholderKey:
+          "openClawResourcesPage.channelEditors.wecom.fields.secret.placeholder",
+      },
+    ],
+    readFormState: readWeComChannelFormState,
+    updateContentText: updateWeComChannelContentText,
   },
   feishu: {
     id: "feishu",
@@ -759,6 +844,7 @@ const bundleFormFromItem = (item: OpenClawConfigBundle) => ({
   description: item.description || "",
   enabled: item.enabled,
   itemIds: item.items.map((bundleItem) => bundleItem.resource_id),
+  skillIds: (item.skill_items || []).map((bundleSkill) => bundleSkill.skill_id),
 });
 
 const skillRiskKey = (riskLevel?: string | null) => {
@@ -931,6 +1017,17 @@ const OpenClawConfigCenterPage: React.FC = () => {
         items: resources.filter((item) => item.resource_type === value),
       })),
     [resourceTypeOptions, resources],
+  );
+  const bundleSkillOptions = useMemo(
+    () =>
+      skills.filter(
+        (item) =>
+          bundleForm.skillIds.includes(item.id) ||
+          (item.status === "active" &&
+            item.risk_level !== "medium" &&
+            item.risk_level !== "high"),
+      ),
+    [bundleForm.skillIds, skills],
   );
 
   const selectedChannelTemplate = useMemo(
@@ -1294,6 +1391,13 @@ const OpenClawConfigCenterPage: React.FC = () => {
         items: bundleForm.itemIds.map(
           (resourceId, index): OpenClawConfigBundleItem => ({
             resource_id: resourceId,
+            sort_order: index + 1,
+            required: true,
+          }),
+        ),
+        skill_items: bundleForm.skillIds.map(
+          (skillId, index): OpenClawConfigBundleSkillItem => ({
+            skill_id: skillId,
             sort_order: index + 1,
             required: true,
           }),
@@ -1786,7 +1890,9 @@ const OpenClawConfigCenterPage: React.FC = () => {
                         </div>
                         <div className="mt-1 text-xs text-gray-500">
                           {t("openClawResourcesPage.bundleResourceCount", {
-                            count: item.items.length,
+                            count:
+                              item.items.length +
+                              (item.skill_items?.length || 0),
                           })}
                         </div>
                         {item.description && (
@@ -2423,6 +2529,53 @@ const OpenClawConfigCenterPage: React.FC = () => {
                   </div>
                 </div>
               ))}
+              <div>
+                <div className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-[#b46c50]">
+                  {t("openClawResourcesPage.uploadedSkills")}
+                </div>
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                  {bundleSkillOptions.map((item) => {
+                    const checked = bundleForm.skillIds.includes(item.id);
+                    return (
+                      <label
+                        key={item.id}
+                        className={`flex cursor-pointer items-start gap-3 rounded-2xl border px-4 py-3 ${checked ? "border-indigo-300 bg-indigo-50" : "border-gray-200 bg-white"}`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={(e) =>
+                            setBundleForm((current) => ({
+                              ...current,
+                              skillIds: e.target.checked
+                                ? [...current.skillIds, item.id]
+                                : current.skillIds.filter(
+                                    (value) => value !== item.id,
+                                  ),
+                            }))
+                          }
+                        />
+                        <span>
+                          <span className="block font-medium text-gray-900">
+                            {item.name}
+                          </span>
+                          <span className="mt-1 block text-xs text-gray-500">
+                            {item.skill_key}
+                          </span>
+                          <span className="mt-1 block text-xs text-gray-500">
+                            {getSkillRiskLabel(item.risk_level)}
+                          </span>
+                        </span>
+                      </label>
+                    );
+                  })}
+                  {bundleSkillOptions.length === 0 && (
+                    <div className="rounded-2xl border border-dashed border-gray-300 px-4 py-3 text-sm text-gray-500">
+                      {t("openClawResourcesPage.noUploadedSkillsForBundle")}
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
           </div>
 

--- a/frontend/src/pages/teams/TeamDetailPage.tsx
+++ b/frontend/src/pages/teams/TeamDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+﻿import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { InstanceAccess } from "../../components/InstanceAccess";
 import UserLayout from "../../components/UserLayout";
@@ -82,6 +82,25 @@ const parseJsonRecord = (value: unknown): Record<string, unknown> | undefined =>
     return undefined;
   }
 };
+
+const TEAM_TASK_HISTORY_PAGE_SIZE = 20;
+const TEAM_EVENT_HISTORY_PAGE_SIZE = 50;
+
+const mergeByIdDesc = <T extends { id: number }>(...groups: T[][]) => {
+  const merged = new Map<number, T>();
+  for (const group of groups) {
+    for (const item of group) {
+      merged.set(item.id, item);
+    }
+  }
+  return [...merged.values()].sort((a, b) => b.id - a.id);
+};
+
+const oldestID = (items: { id: number }[]) =>
+  items.reduce<number | undefined>(
+    (current, item) => (current === undefined ? item.id : Math.min(current, item.id)),
+    undefined,
+  );
 
 const normalizeEventPayload = (event: TeamEvent) => {
   const payload = event.payload || {};
@@ -267,28 +286,56 @@ const collaborationEventType = (
   payload: Record<string, unknown>,
 ) => payloadText(payload, ["event", "event_type", "type"]) || event.event_type;
 
-const taskKeyFromEvent = (
-  event: TeamEvent,
-  payload: Record<string, unknown>,
-) => {
-  if (event.task_id) {
-    return `clawmanager-task-${event.task_id}`;
-  }
-  const taskId = payloadText(payload, [
+const canonicalTaskKey = (taskId: number | string) => `clawmanager-task-${taskId}`;
+
+const payloadTaskIDs = (payload: Record<string, unknown>) =>
+  [
     "taskId",
     "task_id",
     "currentTaskId",
     "runtimeTaskId",
     "MessageThreadId",
-  ]);
+  ]
+    .map((key) => payloadText(payload, [key]))
+    .filter(Boolean);
+
+const taskCreatorKey = (task?: TeamTask) =>
+  task?.created_by ? `user-${task.created_by}` : "user";
+
+const taskKeyFromEvent = (
+  event: TeamEvent,
+  payload: Record<string, unknown>,
+  taskKeyByEventTaskID: Map<string, string>,
+  taskKeyByMessageID: Map<string, string>,
+) => {
+  if (event.task_id) {
+    return canonicalTaskKey(event.task_id);
+  }
+  const messageId = payloadText(payload, ["messageId", "message_id"]) || event.message_id;
+  if (messageId) {
+    const taskKey = taskKeyByMessageID.get(messageId);
+    if (taskKey) {
+      return taskKey;
+    }
+  }
+  for (const taskId of payloadTaskIDs(payload)) {
+    const taskKey = taskKeyByEventTaskID.get(taskId);
+    if (taskKey) {
+      return taskKey;
+    }
+  }
+  const taskId = payloadTaskIDs(payload)[0];
   if (taskId) {
     return taskId;
   }
   const inReplyTo = payloadText(payload, ["inReplyTo", "in_reply_to"]);
   if (inReplyTo) {
+    const taskKey = taskKeyByMessageID.get(inReplyTo);
+    if (taskKey) {
+      return taskKey;
+    }
     return `reply:${inReplyTo}`;
   }
-  const messageId = payloadText(payload, ["messageId", "message_id"]) || event.message_id;
   if (messageId) {
     return `message:${messageId}`;
   }
@@ -350,6 +397,29 @@ const routeFromItem = (item: CollaborationItem) =>
     value && values.indexOf(value) === index,
   );
 
+const eventActorKey = (
+  event: TeamEvent,
+  payload: Record<string, unknown>,
+  eventType: string,
+  from: string,
+  memberById: Map<number, TeamMember>,
+  task?: TeamTask,
+) => {
+  if ((eventType === "outbound" || eventType === "task_assigned") && task?.created_by) {
+    return taskCreatorKey(task);
+  }
+  if (from && from !== "clawmanager") {
+    return from;
+  }
+  if (from === "clawmanager" && task?.created_by) {
+    return taskCreatorKey(task);
+  }
+  if (event.member_id) {
+    return memberById.get(event.member_id)?.member_key || `#${event.member_id}`;
+  }
+  return payloadText(payload, ["memberId", "member_id", "from", "to"]) || "system";
+};
+
 const inferGroupStatus = (items: CollaborationItem[], task?: TeamTask) => {
   if (task?.status) {
     return task.status;
@@ -395,38 +465,40 @@ const buildCollaborationGroups = (
   memberById: Map<number, TeamMember>,
 ) => {
   const taskByID = new Map(tasks.map((task) => [task.id, task]));
-  const taskByMessageID = new Map(
-    tasks
-      .filter((task) => task.message_id)
-      .map((task) => [task.message_id, task]),
-  );
-  const messageTaskKeys = new Map<string, string>();
+  const taskByKey = new Map<string, TeamTask>();
+  const taskKeyByEventTaskID = new Map<string, string>();
+  const taskKeyByMessageID = new Map<string, string>();
+
   for (const task of tasks) {
+    const taskKey = canonicalTaskKey(task.id);
+    taskByKey.set(taskKey, task);
+    taskKeyByEventTaskID.set(taskKey, taskKey);
+    taskKeyByEventTaskID.set(String(task.id), taskKey);
+    taskKeyByEventTaskID.set(`team-${task.team_id}-task-${task.id}`, taskKey);
     if (task.message_id) {
-      messageTaskKeys.set(task.message_id, `clawmanager-task-${task.id}`);
+      taskKeyByMessageID.set(task.message_id, taskKey);
     }
   }
+
   for (const event of events) {
     const payload = normalizeEventPayload(event);
-    const taskKey = event.task_id
-      ? `clawmanager-task-${event.task_id}`
-      : payloadText(payload, [
-          "taskId",
-          "task_id",
-          "currentTaskId",
-          "runtimeTaskId",
-          "MessageThreadId",
-        ]);
-    if (!taskKey) {
+    const messageID = payloadText(payload, ["messageId", "message_id"]) || event.message_id;
+    const canonicalKey =
+      (event.task_id ? canonicalTaskKey(event.task_id) : "") ||
+      (messageID && taskKeyByMessageID.get(messageID)) ||
+      "";
+    if (!canonicalKey) {
       continue;
     }
-    const messageID = payloadText(payload, ["messageId", "message_id"]) || event.message_id;
+    for (const taskID of payloadTaskIDs(payload)) {
+      taskKeyByEventTaskID.set(taskID, canonicalKey);
+    }
     const inReplyTo = payloadText(payload, ["inReplyTo", "in_reply_to"]);
     if (messageID) {
-      messageTaskKeys.set(messageID, taskKey);
+      taskKeyByMessageID.set(messageID, canonicalKey);
     }
     if (inReplyTo) {
-      messageTaskKeys.set(inReplyTo, taskKey);
+      taskKeyByMessageID.set(inReplyTo, canonicalKey);
     }
   }
   const groups = new Map<string, CollaborationGroup>();
@@ -434,24 +506,18 @@ const buildCollaborationGroups = (
   for (const event of events) {
     const payload = normalizeEventPayload(event);
     const eventType = collaborationEventType(event, payload);
-    const actor =
-      event.member_id
-        ? memberById.get(event.member_id)?.member_key || `#${event.member_id}`
-        : payloadText(payload, ["memberId", "member_id", "from", "to"]) || "system";
     const from = payloadText(payload, ["from"]);
     const to = payloadText(payload, ["to", "recipient", "memberId"]);
-    let taskKey = taskKeyFromEvent(event, payload);
-    const messageID = payloadText(payload, ["messageId", "message_id"]) || event.message_id;
-    const inReplyTo = payloadText(payload, ["inReplyTo", "in_reply_to"]);
-    const mappedTaskKey =
-      (messageID && messageTaskKeys.get(messageID)) ||
-      (inReplyTo && messageTaskKeys.get(inReplyTo));
-    if (mappedTaskKey && (taskKey.startsWith("message:") || taskKey.startsWith("reply:"))) {
-      taskKey = mappedTaskKey;
-    }
+    const taskKey = taskKeyFromEvent(
+      event,
+      payload,
+      taskKeyByEventTaskID,
+      taskKeyByMessageID,
+    );
     const existingTask =
-      (event.task_id ? taskByID.get(event.task_id) : undefined) ||
-      (messageID ? taskByMessageID.get(messageID) : undefined);
+      taskByKey.get(taskKey) ||
+      (event.task_id ? taskByID.get(event.task_id) : undefined);
+    const actor = eventActorKey(event, payload, eventType, from, memberById, existingTask);
     const item: CollaborationItem = {
       event,
       payload,
@@ -492,7 +558,7 @@ const buildCollaborationGroups = (
   }
 
   for (const task of tasks) {
-    const key = `clawmanager-task-${task.id}`;
+    const key = canonicalTaskKey(task.id);
     if (!groups.has(key)) {
       const target = memberById.get(task.target_member_id)?.member_key || `#${task.target_member_id}`;
       groups.set(key, {
@@ -523,6 +589,14 @@ const TeamDetailPage: React.FC = () => {
   const { user } = useAuth();
   const teamId = id ? Number(id) : null;
   const [details, setDetails] = useState<TeamDetails | null>(null);
+  const [loadedTasks, setLoadedTasks] = useState<TeamTask[]>([]);
+  const [loadedEvents, setLoadedEvents] = useState<TeamEvent[]>([]);
+  const [hasMoreTasks, setHasMoreTasks] = useState(false);
+  const [hasMoreEvents, setHasMoreEvents] = useState(false);
+  const taskHistoryExhausted = useRef(false);
+  const eventHistoryExhausted = useRef(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -540,6 +614,16 @@ const TeamDetailPage: React.FC = () => {
     null,
   );
 
+  useEffect(() => {
+    setLoadedTasks([]);
+    setLoadedEvents([]);
+    setHasMoreTasks(false);
+    setHasMoreEvents(false);
+    taskHistoryExhausted.current = false;
+    eventHistoryExhausted.current = false;
+    setHistoryError(null);
+  }, [teamId]);
+
   const loadTeam = useCallback(
     async (options?: { background?: boolean }) => {
       if (!teamId || Number.isNaN(teamId)) {
@@ -555,6 +639,18 @@ const TeamDetailPage: React.FC = () => {
         }
         const data = await teamService.getTeam(teamId);
         setDetails(data);
+        setLoadedTasks((current) => mergeByIdDesc(data.tasks || [], current));
+        setLoadedEvents((current) => mergeByIdDesc(data.events || [], current));
+        setHasMoreTasks((current) =>
+          taskHistoryExhausted.current
+            ? false
+            : current || (data.tasks?.length || 0) >= TEAM_TASK_HISTORY_PAGE_SIZE,
+        );
+        setHasMoreEvents((current) =>
+          eventHistoryExhausted.current
+            ? false
+            : current || (data.events?.length || 0) >= TEAM_EVENT_HISTORY_PAGE_SIZE,
+        );
         setError(null);
         setTargetMember((current) => current || "");
         setDesktopMemberId((current) =>
@@ -592,8 +688,8 @@ const TeamDetailPage: React.FC = () => {
   const leader = details?.leader || details?.members.find((member) => member.role === "leader");
   const selectedDesktopMember =
     details?.members.find((member) => member.id === desktopMemberId) || leader;
-  const tasks = details?.tasks || [];
-  const events = details?.events || [];
+  const tasks = loadedTasks.length > 0 ? loadedTasks : details?.tasks || [];
+  const events = loadedEvents.length > 0 ? loadedEvents : details?.events || [];
   const selectedMemberInstanceResolved =
     selectedMemberInstance?.id === selectedDesktopMember?.instance_id;
   const selectedAccessRuntimeType = selectedMemberInstanceResolved && selectedMemberInstance
@@ -699,6 +795,38 @@ const TeamDetailPage: React.FC = () => {
       setDispatchError(err.response?.data?.error || "派发任务失败");
     } finally {
       setDispatching(false);
+    }
+  };
+
+  const handleLoadMoreHistory = async () => {
+    if (!teamId || historyLoading || (!hasMoreTasks && !hasMoreEvents)) {
+      return;
+    }
+    try {
+      setHistoryLoading(true);
+      setHistoryError(null);
+      const [taskHistory, eventHistory] = await Promise.all([
+        hasMoreTasks
+          ? teamService.getTeamTasks(teamId, oldestID(tasks), TEAM_TASK_HISTORY_PAGE_SIZE)
+          : Promise.resolve(null),
+        hasMoreEvents
+          ? teamService.getTeamEvents(teamId, oldestID(events), TEAM_EVENT_HISTORY_PAGE_SIZE)
+          : Promise.resolve(null),
+      ]);
+      if (taskHistory) {
+        setLoadedTasks((current) => mergeByIdDesc(current, taskHistory.tasks || []));
+        setHasMoreTasks(taskHistory.has_more);
+        taskHistoryExhausted.current = !taskHistory.has_more;
+      }
+      if (eventHistory) {
+        setLoadedEvents((current) => mergeByIdDesc(current, eventHistory.events || []));
+        setHasMoreEvents(eventHistory.has_more);
+        eventHistoryExhausted.current = !eventHistory.has_more;
+      }
+    } catch (err: any) {
+      setHistoryError(err.response?.data?.error || "加载历史消息失败");
+    } finally {
+      setHistoryLoading(false);
     }
   };
 
@@ -842,8 +970,12 @@ const TeamDetailPage: React.FC = () => {
             taskPrompt={taskPrompt}
             dispatching={dispatching}
             dispatchError={dispatchError}
+            historyLoading={historyLoading}
+            historyError={historyError}
+            hasMoreHistory={hasMoreTasks || hasMoreEvents}
             onTaskPromptChange={setTaskPrompt}
             onDispatch={handleDispatch}
+            onLoadMoreHistory={handleLoadMoreHistory}
           />
         </div>
 
@@ -1088,8 +1220,12 @@ function CollaborationPanel({
   taskPrompt,
   dispatching,
   dispatchError,
+  historyLoading,
+  historyError,
+  hasMoreHistory,
   onTaskPromptChange,
   onDispatch,
+  onLoadMoreHistory,
 }: {
   team: TeamDetails["team"];
   events: TeamEvent[];
@@ -1102,8 +1238,12 @@ function CollaborationPanel({
   taskPrompt: string;
   dispatching: boolean;
   dispatchError: string | null;
+  historyLoading: boolean;
+  historyError: string | null;
+  hasMoreHistory: boolean;
   onTaskPromptChange: (value: string) => void;
   onDispatch: (event: React.FormEvent) => void;
+  onLoadMoreHistory: () => void;
 }) {
   const groups = buildCollaborationGroups(events, tasks, memberById);
   const messages = buildTeamChatMessages(
@@ -1134,11 +1274,41 @@ function CollaborationPanel({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto bg-[#f5f5f5]">
+      <div
+        className="min-h-0 flex-1 overflow-auto bg-[#f5f5f5]"
+        onScroll={(event) => {
+          if (event.currentTarget.scrollTop <= 24 && hasMoreHistory && !historyLoading) {
+            void onLoadMoreHistory();
+          }
+        }}
+      >
         {messages.length === 0 ? (
           <div className="p-6 text-center text-xs text-gray-500">暂无群聊消息。</div>
         ) : (
           <div className="space-y-5 px-4 py-5">
+            {(hasMoreHistory || historyLoading || historyError) && (
+              <div className="space-y-2 text-center">
+                {hasMoreHistory && (
+                  <button
+                    type="button"
+                    disabled={historyLoading}
+                    onClick={() => void onLoadMoreHistory()}
+                    className="inline-flex items-center gap-2 rounded-full border border-[#dddddd] bg-white px-4 py-2 text-xs font-medium text-gray-500 shadow-sm transition hover:border-gray-300 hover:text-gray-700 disabled:cursor-wait disabled:opacity-70"
+                  >
+                    <span className="text-base leading-none">↑</span>
+                    <span>{historyLoading ? "加载历史消息中..." : "向上滑动或点击查看更多历史消息"}</span>
+                  </button>
+                )}
+                {!hasMoreHistory && historyLoading && (
+                  <span className="inline-flex rounded-full border border-[#dddddd] bg-white px-4 py-2 text-xs text-gray-500 shadow-sm">
+                    加载历史消息中...
+                  </span>
+                )}
+                {historyError && (
+                  <div className="text-xs text-red-600">{historyError}</div>
+                )}
+              </div>
+            )}
             <TimeDivider value={messages[0]?.time} />
             {messages.map((message) =>
               message.kind === "system" ? (
@@ -1200,6 +1370,9 @@ type TeamChatMessage = {
   content: string;
   time: number;
   tone?: "normal" | "leader" | "assignment" | "feedback" | "error";
+  dedupeKey?: string;
+  threadKey?: string;
+  sortPhase?: number;
 };
 
 function buildTeamChatMessages(
@@ -1219,15 +1392,27 @@ function buildTeamChatMessages(
         memberById.get(group.task.target_member_id)?.member_key ||
         `#${group.task.target_member_id}`;
       const targetLabel = displayMemberName(target, memberByKey, leaderMemberId);
+      const creatorKey = taskCreatorKey(group.task);
       const prompt = taskPromptText(group.task) || group.title;
+      const assignmentSenderKey =
+        creatorKey === currentUserKey || creatorKey === "user"
+          ? currentUserKey
+          : creatorKey;
+      const assignmentSender =
+        assignmentSenderKey === currentUserKey
+          ? currentUserLabel
+          : displayMemberName(creatorKey, memberByKey, leaderMemberId);
       messages.push({
         id: `task-${group.task.id}`,
         kind: "member",
-        sender: currentUserLabel,
-        senderKey: currentUserKey,
+        sender: assignmentSender,
+        senderKey: assignmentSenderKey,
         content: `@${targetLabel} ${prompt}\n任务：${group.task.message_id || group.label}`,
         time: new Date(group.task.created_at).getTime(),
         tone: "assignment",
+        dedupeKey: `assignment:${group.task.message_id || group.task.id}`,
+        threadKey: group.key,
+        sortPhase: 0,
       });
       const resultSummary =
         payloadText(group.task.result, ["summary", "result", "message", "text"]) ||
@@ -1241,6 +1426,9 @@ function buildTeamChatMessages(
           content: `任务结果反馈：\n${resultSummary}`,
           time: new Date(group.task.finished_at || group.task.updated_at).getTime(),
           tone: "feedback",
+          dedupeKey: `feedback:${group.task.message_id || group.task.id}:${normalizeChatDedupeContent(resultSummary)}`,
+          threadKey: group.key,
+          sortPhase: 2,
         });
       }
       if (group.task.error_message && group.items.length === 0) {
@@ -1252,6 +1440,9 @@ function buildTeamChatMessages(
           content: `失败：${group.task.error_message}`,
           time: new Date(group.task.updated_at).getTime(),
           tone: "error",
+          dedupeKey: `error:${group.task.message_id || group.task.id}:${normalizeChatDedupeContent(group.task.error_message)}`,
+          threadKey: group.key,
+          sortPhase: 2,
         });
       }
     }
@@ -1268,7 +1459,18 @@ function buildTeamChatMessages(
   }
   return messages
     .filter((message) => Number.isFinite(message.time))
-    .sort((a, b) => a.time - b.time || a.id.localeCompare(b.id));
+    .sort(compareTeamChatMessages)
+    .filter(dedupeTeamChatMessage());
+}
+
+function compareTeamChatMessages(a: TeamChatMessage, b: TeamChatMessage) {
+  if (a.threadKey && a.threadKey === b.threadKey) {
+    const phaseDiff = (a.sortPhase ?? 1) - (b.sortPhase ?? 1);
+    if (phaseDiff !== 0) {
+      return phaseDiff;
+    }
+  }
+  return a.time - b.time || a.id.localeCompare(b.id);
 }
 
 function itemMessageID(item: CollaborationItem) {
@@ -1314,14 +1516,14 @@ function chatMessageFromItem(
     isAssignmentEvent && !hasContent
       ? assignmentEventFallback(item, senderLabel, targetLabel, isFeedbackEvent)
       : chatFallbackText(item, progress, status);
+  const content = item.content || fallbackContent;
+  const isTerminalFeedback = isTerminalFeedbackItem(item, content, isFeedbackEvent);
   return {
     id: `event-${item.event.id}`,
     kind: isSystem ? "system" : "member",
     sender: isSystem ? "系统" : senderLabel,
     senderKey,
-    content:
-      item.content ||
-      fallbackContent,
+    content,
     time: item.timeMs,
     tone:
       isAssignmentEvent && hasContent
@@ -1335,7 +1537,93 @@ function chatMessageFromItem(
           : senderKey === leaderMemberId || senderKey === "ClawManager"
             ? "leader"
             : "normal",
+    dedupeKey: chatItemDedupeKey(item, senderKey, content, isAssignmentEvent, isFeedbackEvent),
+    threadKey: item.taskKey,
+    sortPhase: chatItemSortPhase(item, isAssignmentEvent, isTerminalFeedback),
   };
+}
+
+function chatItemSortPhase(
+  item: CollaborationItem,
+  isAssignmentEvent: boolean,
+  isTerminalFeedback: boolean,
+) {
+  if (isAssignmentEvent && !isTerminalFeedback) {
+    return 0;
+  }
+  if (
+    isTerminalFeedback ||
+    item.eventType === "task_stale" ||
+    item.eventType === "task_failed" ||
+    item.eventType === "message_failed"
+  ) {
+    return 2;
+  }
+  return 1;
+}
+
+function isTerminalFeedbackItem(
+  item: CollaborationItem,
+  content: string,
+  isFeedbackEvent: boolean,
+) {
+  if (
+    item.eventType === "task_completed" ||
+    item.eventType === "completion" ||
+    item.eventType === "task_failed" ||
+    item.eventType === "message_failed"
+  ) {
+    return true;
+  }
+  return isFeedbackEvent && finalFeedbackContentPattern.test(content);
+}
+
+const finalFeedbackContentPattern =
+  /\bDONE\b|team_complete_task|任务核心结果|完整详细产出|结果已反馈|已完成|执行完成|完成任务/;
+
+function dedupeTeamChatMessage() {
+  const seen = new Set<string>();
+  return (message: TeamChatMessage) => {
+    if (!message.dedupeKey) {
+      return true;
+    }
+    if (seen.has(message.dedupeKey)) {
+      return false;
+    }
+    seen.add(message.dedupeKey);
+    return true;
+  };
+}
+
+function chatItemDedupeKey(
+  item: CollaborationItem,
+  senderKey: string,
+  content: string,
+  isAssignmentEvent: boolean,
+  isFeedbackEvent: boolean,
+) {
+  const messageId =
+    payloadTextDeep(item.payload, ["messageId", "message_id", "inReplyTo", "in_reply_to"]) ||
+    item.event.message_id ||
+    "";
+  const taskId =
+    payloadTextDeep(item.payload, ["taskId", "task_id", "runtimeTaskId"]) ||
+    (item.event.task_id ? canonicalTaskKey(item.event.task_id) : item.taskKey);
+  const contentKey = normalizeChatDedupeContent(content);
+  if (isAssignmentEvent) {
+    return `assignment:${messageId || taskId}:${senderKey}:${item.to || ""}:${contentKey}`;
+  }
+  if (isFeedbackEvent) {
+    return `feedback:${messageId || taskId}:${senderKey}:${item.to || ""}:${contentKey}`;
+  }
+  if (item.eventType === "task_completed" || item.eventType === "completion" || item.eventType === "reply") {
+    return `feedback:${messageId || taskId}:${senderKey}:${item.to || ""}:${contentKey}`;
+  }
+  return "";
+}
+
+function normalizeChatDedupeContent(content: string) {
+  return content.trim().replace(/\s+/g, " ").slice(0, 240);
 }
 
 function assignmentEventFallback(
@@ -1425,6 +1713,12 @@ function displayMemberName(
   }
   if (memberKey === "ClawManager") {
     return "ClawManager（system）";
+  }
+  if (memberKey === "user") {
+    return "User";
+  }
+  if (memberKey.startsWith("user-")) {
+    return `User #${memberKey.slice("user-".length)}`;
   }
   return memberKey;
 }

--- a/frontend/src/services/teamService.ts
+++ b/frontend/src/services/teamService.ts
@@ -3,8 +3,10 @@ import type {
   CreateTeamRequest,
   DispatchTeamTaskRequest,
   TeamDetails,
+  TeamEventsHistoryResponse,
   TeamListResponse,
   TeamTask,
+  TeamTasksHistoryResponse,
 } from "../types/team";
 
 export const teamService = {
@@ -25,6 +27,28 @@ export const teamService = {
 
   getTeam: async (id: number): Promise<TeamDetails> => {
     const response = await api.get(`/teams/${id}`);
+    return response.data.data;
+  },
+
+  getTeamTasks: async (
+    id: number,
+    beforeId?: number,
+    limit: number = 20,
+  ): Promise<TeamTasksHistoryResponse> => {
+    const response = await api.get(`/teams/${id}/tasks`, {
+      params: { before_id: beforeId, limit },
+    });
+    return response.data.data;
+  },
+
+  getTeamEvents: async (
+    id: number,
+    beforeId?: number,
+    limit: number = 50,
+  ): Promise<TeamEventsHistoryResponse> => {
+    const response = await api.get(`/teams/${id}/events`, {
+      params: { before_id: beforeId, limit },
+    });
     return response.data.data;
   },
 

--- a/frontend/src/types/openclawConfig.ts
+++ b/frontend/src/types/openclawConfig.ts
@@ -43,6 +43,26 @@ export interface OpenClawConfigBundleItem {
   resource?: OpenClawConfigResourceSummary;
 }
 
+export interface OpenClawConfigBundleSkillItem {
+  skill_id: number;
+  sort_order: number;
+  required: boolean;
+  skill?: {
+    id: number;
+    user_id: number;
+    skill_key: string;
+    name: string;
+    description?: string;
+    status: string;
+    source_type: string;
+    risk_level: string;
+    current_version_id?: number;
+    last_scanned_at?: string;
+    created_at: string;
+    updated_at: string;
+  };
+}
+
 export interface OpenClawConfigBundle {
   id: number;
   user_id: number;
@@ -51,6 +71,7 @@ export interface OpenClawConfigBundle {
   enabled: boolean;
   version: number;
   items: OpenClawConfigBundleItem[];
+  skill_items?: OpenClawConfigBundleSkillItem[];
   created_at: string;
   updated_at: string;
 }
@@ -60,6 +81,7 @@ export interface UpsertOpenClawConfigBundleRequest {
   description?: string;
   enabled: boolean;
   items: OpenClawConfigBundleItem[];
+  skill_items?: OpenClawConfigBundleSkillItem[];
 }
 
 export interface OpenClawConfigPlan {

--- a/frontend/src/types/team.ts
+++ b/frontend/src/types/team.ts
@@ -120,6 +120,18 @@ export interface TeamDetails {
   events?: TeamEvent[];
 }
 
+export interface TeamTasksHistoryResponse {
+  tasks: TeamTask[];
+  has_more: boolean;
+  next_before_id?: number;
+}
+
+export interface TeamEventsHistoryResponse {
+  events: TeamEvent[];
+  has_more: boolean;
+  next_before_id?: number;
+}
+
 export interface TeamListResponse {
   teams: Team[];
   total: number;


### PR DESCRIPTION
- Bundle Skills: attach skills to config bundles, auto-resolve on creation. Fix #123.
- WeCom channel: wecom connector with botId/secret/dmPolicy/allowFrom
- CLAWMANAGER_WORKSPACE_ARCHIVE_MAX_MIB controls archive size limit, synced to nginx client_max_body_size via start.sh
- Update deployment manifests, i18n, and frontend UI
