### PR TITLE
Tune desktop clipboard and shared memory defaults

### DIFF
--- a/backend/internal/services/instance_env.go
+++ b/backend/internal/services/instance_env.go
@@ -16,10 +16,11 @@ const (
 )
 
 // popSHMSizeGB removes SHM_SIZE_GB from extraEnv and returns /dev/shm size in GiB.
-// Default is 1 when unset. SHM_SIZE_GB=0 disables the custom emptyDir /dev/shm mount.
+// Desktop runtime defaults scale with instance memory. SHM_SIZE_GB=0 disables
+// the custom emptyDir /dev/shm mount.
 // Values above maxInstanceSHMSizeGB are clamped to protect node memory.
-func popSHMSizeGB(extraEnv map[string]string) int {
-	shmSizeGB := defaultInstanceSHMSizeGB
+func popSHMSizeGB(extraEnv map[string]string, runtimeType string, memoryGB int) int {
+	shmSizeGB := defaultSHMSizeGB(runtimeType, memoryGB)
 	if shmVal, ok := extraEnv["SHM_SIZE_GB"]; ok {
 		if parsed, err := strconv.Atoi(strings.TrimSpace(shmVal)); err == nil {
 			if parsed == 0 {
@@ -34,6 +35,20 @@ func popSHMSizeGB(extraEnv map[string]string) int {
 		delete(extraEnv, "SHM_SIZE_GB")
 	}
 	return shmSizeGB
+}
+
+func defaultSHMSizeGB(runtimeType string, memoryGB int) int {
+	if normalizeInstanceRuntimeType(runtimeType) != "desktop" {
+		return defaultInstanceSHMSizeGB
+	}
+	switch {
+	case memoryGB >= 12:
+		return 4
+	case memoryGB >= 8:
+		return 2
+	default:
+		return defaultInstanceSHMSizeGB
+	}
 }
 
 var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)

--- a/backend/internal/services/instance_env_test.go
+++ b/backend/internal/services/instance_env_test.go
@@ -37,8 +37,9 @@ func TestBuildInstancePodEnvAppliesOverridesAfterDefaults(t *testing.T) {
 	t.Setenv("K8S_NAMESPACE", "")
 
 	raw, err := marshalEnvironmentOverrides(map[string]string{
-		"SUBFOLDER": "/custom-proxy",
-		"CUSTOM":    "enabled",
+		"SUBFOLDER":                "/custom-proxy",
+		"KASM_SVC_ACCEPT_CUT_TEXT": "-AcceptCutText 1",
+		"CUSTOM":                   "enabled",
 	})
 	if err != nil {
 		t.Fatalf("marshalEnvironmentOverrides returned error: %v", err)
@@ -61,6 +62,9 @@ func TestBuildInstancePodEnvAppliesOverridesAfterDefaults(t *testing.T) {
 	if env["SUBFOLDER"] != "/custom-proxy" {
 		t.Fatalf("expected SUBFOLDER override to win, got %q", env["SUBFOLDER"])
 	}
+	if env["KASM_SVC_ACCEPT_CUT_TEXT"] != "-AcceptCutText 1" {
+		t.Fatalf("expected clipboard policy override to win, got %q", env["KASM_SVC_ACCEPT_CUT_TEXT"])
+	}
 	if env["CUSTOM"] != "enabled" {
 		t.Fatalf("expected custom environment variable to be merged")
 	}
@@ -74,14 +78,20 @@ func TestPopSHMSizeGB(t *testing.T) {
 		name     string
 		value    string
 		hasValue bool
+		runtime  string
+		memoryGB int
 		want     int
 	}{
-		{name: "default", want: defaultInstanceSHMSizeGB},
-		{name: "disable", value: "0", hasValue: true, want: 0},
-		{name: "custom", value: "4", hasValue: true, want: 4},
-		{name: "clamp", value: "128", hasValue: true, want: maxInstanceSHMSizeGB},
-		{name: "invalid", value: "nope", hasValue: true, want: defaultInstanceSHMSizeGB},
-		{name: "negative", value: "-1", hasValue: true, want: defaultInstanceSHMSizeGB},
+		{name: "desktop minimum preset", runtime: "desktop", memoryGB: 4, want: defaultInstanceSHMSizeGB},
+		{name: "desktop medium preset", runtime: "desktop", memoryGB: 8, want: 2},
+		{name: "desktop large preset", runtime: "desktop", memoryGB: 12, want: 4},
+		{name: "desktop small fallback", runtime: "desktop", memoryGB: 2, want: defaultInstanceSHMSizeGB},
+		{name: "shell default unchanged", runtime: "shell", memoryGB: 8, want: defaultInstanceSHMSizeGB},
+		{name: "disable", value: "0", hasValue: true, runtime: "desktop", memoryGB: 8, want: 0},
+		{name: "custom", value: "4", hasValue: true, runtime: "desktop", memoryGB: 4, want: 4},
+		{name: "clamp", value: "128", hasValue: true, runtime: "desktop", memoryGB: 8, want: maxInstanceSHMSizeGB},
+		{name: "invalid keeps dynamic desktop default", value: "nope", hasValue: true, runtime: "desktop", memoryGB: 8, want: 2},
+		{name: "negative keeps dynamic desktop default", value: "-1", hasValue: true, runtime: "desktop", memoryGB: 4, want: defaultInstanceSHMSizeGB},
 	}
 
 	for _, tt := range tests {
@@ -91,7 +101,7 @@ func TestPopSHMSizeGB(t *testing.T) {
 				extraEnv["SHM_SIZE_GB"] = tt.value
 			}
 
-			got := popSHMSizeGB(extraEnv)
+			got := popSHMSizeGB(extraEnv, tt.runtime, tt.memoryGB)
 			if got != tt.want {
 				t.Fatalf("expected shm size %d, got %d", tt.want, got)
 			}

--- a/backend/internal/services/instance_runtime.go
+++ b/backend/internal/services/instance_runtime.go
@@ -16,6 +16,11 @@ type InstanceRuntimeConfig struct {
 	Env       map[string]string
 }
 
+const (
+	kasmClipboardSendDisabled   = "-SendCutText 0"
+	kasmClipboardAcceptDisabled = "-AcceptCutText 0"
+)
+
 func buildRuntimeConfig(instanceType, osType, osVersion string, registry, tag *string) InstanceRuntimeConfig {
 	if registry != nil && strings.TrimSpace(*registry) != "" && (tag == nil || strings.TrimSpace(*tag) == "") {
 		return InstanceRuntimeConfig{
@@ -47,26 +52,17 @@ func buildRuntimeConfig(instanceType, osType, osVersion string, registry, tag *s
 		config.Image = "lscr.io/linuxserver/webtop:ubuntu-xfce"
 		config.Port = 3001
 		config.MountPath = "/config"
-		config.Env = map[string]string{
-			"TITLE":     "ClawManager Desktop",
-			"SUBFOLDER": "/",
-		}
+		config.Env = defaultWebtopDesktopEnv("ClawManager Desktop")
 	case "webtop":
 		config.Image = "lscr.io/linuxserver/webtop:ubuntu-xfce"
 		config.Port = 3001
 		config.MountPath = "/config"
-		config.Env = map[string]string{
-			"TITLE":     "ClawManager Webtop",
-			"SUBFOLDER": "/",
-		}
+		config.Env = defaultWebtopDesktopEnv("ClawManager Webtop")
 	case "hermes":
 		config.Image = defaultSystemImageSettings["hermes"]
 		config.Port = 3001
 		config.MountPath = "/config/.hermes"
-		config.Env = map[string]string{
-			"TITLE":     "Hermes Runtime",
-			"SUBFOLDER": "/",
-		}
+		config.Env = defaultWebtopDesktopEnv("Hermes Runtime")
 	case "openclaw":
 		config.MountPath = "/config"
 		if (registry == nil || strings.TrimSpace(*registry) == "") && (tag == nil || strings.TrimSpace(*tag) == "") {
@@ -74,10 +70,7 @@ func buildRuntimeConfig(instanceType, osType, osVersion string, registry, tag *s
 		} else {
 			config.Image = fmt.Sprintf("%s/%s:%s", defaultRegistry, "openclaw-desktop", defaultTag)
 		}
-		config.Env = map[string]string{
-			"TITLE":     "ClawManager Desktop",
-			"SUBFOLDER": "/",
-		}
+		config.Env = defaultWebtopDesktopEnv("ClawManager Desktop")
 	case "debian":
 		config.Image = fmt.Sprintf("%s/%s:%s", defaultRegistry, "debian-desktop", defaultTag)
 	case "centos":
@@ -111,17 +104,20 @@ func defaultMountPathForInstanceType(instanceType string) string {
 func defaultEnvForInstanceType(instanceType string) map[string]string {
 	switch instanceType {
 	case "ubuntu", "webtop", "openclaw":
-		return map[string]string{
-			"TITLE":     "ClawManager Desktop",
-			"SUBFOLDER": "/",
-		}
+		return defaultWebtopDesktopEnv("ClawManager Desktop")
 	case "hermes":
-		return map[string]string{
-			"TITLE":     "Hermes Runtime",
-			"SUBFOLDER": "/",
-		}
+		return defaultWebtopDesktopEnv("Hermes Runtime")
 	default:
 		return map[string]string{}
+	}
+}
+
+func defaultWebtopDesktopEnv(title string) map[string]string {
+	return map[string]string{
+		"TITLE":                    title,
+		"SUBFOLDER":                "/",
+		"KASM_SVC_SEND_CUT_TEXT":   kasmClipboardSendDisabled,
+		"KASM_SVC_ACCEPT_CUT_TEXT": kasmClipboardAcceptDisabled,
 	}
 }
 

--- a/backend/internal/services/instance_runtime_test.go
+++ b/backend/internal/services/instance_runtime_test.go
@@ -34,7 +34,24 @@ func TestBuildRuntimeConfig_HermesUsesWebtopDefaults(t *testing.T) {
 	if config.Env["SUBFOLDER"] != "/" {
 		t.Fatalf("expected Hermes default SUBFOLDER /, got %q", config.Env["SUBFOLDER"])
 	}
+	if config.Env["KASM_SVC_SEND_CUT_TEXT"] != kasmClipboardSendDisabled {
+		t.Fatalf("expected Hermes to disable outbound clipboard sync, got %q", config.Env["KASM_SVC_SEND_CUT_TEXT"])
+	}
+	if config.Env["KASM_SVC_ACCEPT_CUT_TEXT"] != kasmClipboardAcceptDisabled {
+		t.Fatalf("expected Hermes to disable inbound clipboard sync, got %q", config.Env["KASM_SVC_ACCEPT_CUT_TEXT"])
+	}
 	if !usesWebtopImage("hermes") {
 		t.Fatalf("expected Hermes to use webtop proxy behavior")
+	}
+}
+
+func TestBuildRuntimeConfig_OpenClawDisablesKasmClipboardSync(t *testing.T) {
+	config := buildRuntimeConfig("openclaw", "openclaw", "latest", nil, nil)
+
+	if config.Env["KASM_SVC_SEND_CUT_TEXT"] != kasmClipboardSendDisabled {
+		t.Fatalf("expected OpenClaw to disable outbound clipboard sync, got %q", config.Env["KASM_SVC_SEND_CUT_TEXT"])
+	}
+	if config.Env["KASM_SVC_ACCEPT_CUT_TEXT"] != kasmClipboardAcceptDisabled {
+		t.Fatalf("expected OpenClaw to disable inbound clipboard sync, got %q", config.Env["KASM_SVC_ACCEPT_CUT_TEXT"])
 	}
 }

--- a/backend/internal/services/instance_service.go
+++ b/backend/internal/services/instance_service.go
@@ -435,7 +435,7 @@ func (s *instanceService) Create(userID int, req CreateInstanceRequest) (*models
 	}
 
 	// Create Pod
-	shmSizeGB := popSHMSizeGB(extraEnv)
+	shmSizeGB := popSHMSizeGB(extraEnv, runtimeType, instance.MemoryGB)
 	envFromSecretNames := []string{bootstrapSecretName}
 	extraPVCMounts := []k8s.PVCMount{}
 	configMapFileMounts := []k8s.ConfigMapFileMount{}
@@ -660,13 +660,14 @@ func (s *instanceService) Start(instanceID int) error {
 		return fmt.Errorf("failed to delete network policy: %w", err)
 	}
 
-	shmSizeGB := popSHMSizeGB(extraEnv)
+	runtimeType := normalizeInstanceRuntimeType(instance.RuntimeType)
+	shmSizeGB := popSHMSizeGB(extraEnv, runtimeType, instance.MemoryGB)
 	podConfig := k8s.PodConfig{
 		InstanceID:         instance.ID,
 		InstanceName:       instance.Name,
 		UserID:             instance.UserID,
 		Type:               instance.Type,
-		RuntimeType:        normalizeInstanceRuntimeType(instance.RuntimeType),
+		RuntimeType:        runtimeType,
 		CPUCores:           instance.CPUCores,
 		MemoryGB:           instance.MemoryGB,
 		GPUEnabled:         instance.GPUEnabled,

--- a/backend/internal/services/openclaw_config_service.go
+++ b/backend/internal/services/openclaw_config_service.go
@@ -1526,7 +1526,13 @@ func appendCompiledOpenClawEnvPayload(payload interface{}, resource compiledOpen
 			return nil, fmt.Errorf("failed to parse openclaw channel config")
 		}
 
-		channelPayload[resource.model.ResourceKey] = normalizeOpenClawChannelConfigForEnv(resource.model.ResourceKey, configPayload)
+		channelKey := openClawChannelEnvKey(resource.model.ResourceKey, configPayload)
+		nextConfig := normalizeOpenClawChannelConfigForEnv(resource.model.ResourceKey, configPayload)
+		if existingConfig, ok := channelPayload[channelKey]; ok {
+			channelPayload[channelKey] = mergeOpenClawChannelEnvConfig(channelKey, resource.model.ResourceKey, existingConfig, nextConfig)
+		} else {
+			channelPayload[channelKey] = nextConfig
+		}
 		return channelPayload, nil
 	}
 
@@ -1549,7 +1555,7 @@ func appendCompiledOpenClawEnvPayload(payload interface{}, resource compiledOpen
 }
 
 func normalizeOpenClawChannelConfigForEnv(resourceKey string, configPayload interface{}) interface{} {
-	switch strings.ToLower(strings.TrimSpace(resourceKey)) {
+	switch detectOpenClawChannelProvider(resourceKey, configPayload) {
 	case "dingtalk-connector":
 		return normalizeDingTalkChannelConfigForEnv(configPayload)
 	case "feishu":
@@ -1563,6 +1569,103 @@ func normalizeOpenClawChannelConfigForEnv(resourceKey string, configPayload inte
 	}
 
 	return configPayload
+}
+
+func openClawChannelEnvKey(resourceKey string, configPayload interface{}) string {
+	provider := detectOpenClawChannelProvider(resourceKey, configPayload)
+	switch provider {
+	case "dingtalk-connector", "feishu", "slack", "telegram", "wecom":
+		return provider
+	}
+	return normalizeResourceKey(resourceKey)
+}
+
+func mergeOpenClawChannelEnvConfig(channelKey, resourceKey string, existing, next interface{}) interface{} {
+	if channelKey == "feishu" {
+		return mergeFeishuChannelEnvConfig(resourceKey, existing, next)
+	}
+	return next
+}
+
+func mergeFeishuChannelEnvConfig(resourceKey string, existing, next interface{}) interface{} {
+	existingMap, existingOk := existing.(map[string]interface{})
+	nextMap, nextOk := next.(map[string]interface{})
+	if !existingOk || !nextOk {
+		return next
+	}
+
+	merged := make(map[string]interface{}, len(existingMap)+len(nextMap))
+	for k, v := range existingMap {
+		merged[k] = v
+	}
+	for k, v := range nextMap {
+		if k != "accounts" && k != "defaultAccount" {
+			merged[k] = v
+		}
+	}
+	if _, ok := merged["defaultAccount"]; !ok {
+		if defaultAccount, ok := nextMap["defaultAccount"]; ok {
+			merged["defaultAccount"] = defaultAccount
+		}
+	}
+
+	mergedAccounts := map[string]interface{}{}
+	if existingAccounts, ok := existingMap["accounts"].(map[string]interface{}); ok {
+		for k, v := range existingAccounts {
+			mergedAccounts[k] = v
+		}
+	}
+	if nextAccounts, ok := nextMap["accounts"].(map[string]interface{}); ok {
+		for accountKey, account := range nextAccounts {
+			mergedAccountKey := accountKey
+			if accountKey == "main" {
+				key := normalizeResourceKey(resourceKey)
+				if _, exists := mergedAccounts["main"]; exists && key != "" && key != "feishu" {
+					mergedAccountKey = key
+				}
+			}
+			mergedAccounts[mergedAccountKey] = account
+		}
+	}
+	merged["accounts"] = mergedAccounts
+	return merged
+}
+
+func detectOpenClawChannelProvider(resourceKey string, configPayload interface{}) string {
+	key := strings.ToLower(strings.TrimSpace(resourceKey))
+	switch key {
+	case "dingtalk-connector", "feishu", "slack", "telegram", "wecom":
+		return key
+	}
+
+	config, ok := configPayload.(map[string]interface{})
+	if !ok {
+		return key
+	}
+	domain, _ := config["domain"].(string)
+	switch strings.ToLower(strings.TrimSpace(domain)) {
+	case "dingtalk", "dingding", "dingtalk-connector":
+		return "dingtalk-connector"
+	case "feishu", "lark":
+		return "feishu"
+	case "wecom", "wechat-work", "work-wechat", "enterprise-wechat", "qywx":
+		return "wecom"
+	}
+	if accounts, ok := config["accounts"].(map[string]interface{}); ok && len(accounts) > 0 {
+		return "feishu"
+	}
+	if _, hasClientID := config["clientId"].(string); hasClientID {
+		if _, hasClientSecret := config["clientSecret"].(string); hasClientSecret {
+			return "dingtalk-connector"
+		}
+	}
+	if _, hasBotID := config["botId"].(string); hasBotID {
+		if _, hasSecret := config["secret"].(string); hasSecret {
+			return "wecom"
+		}
+	}
+
+	return key
 }
 
 // mergeOpenClawChannelConfigForStorage combines the allowlist-normalized config
@@ -1589,7 +1692,7 @@ func mergeOpenClawChannelConfigForStorage(resourceKey string, original, normaliz
 		merged[k] = v
 	}
 
-	if strings.ToLower(strings.TrimSpace(resourceKey)) == "feishu" {
+	if detectOpenClawChannelProvider(resourceKey, original) == "feishu" {
 		originalAccounts, _ := originalMap["accounts"].(map[string]interface{})
 		normalizedAccounts, _ := normalizedMap["accounts"].(map[string]interface{})
 		if originalAccounts != nil || normalizedAccounts != nil {
@@ -1619,18 +1722,29 @@ func mergeOpenClawChannelConfigForStorage(resourceKey string, original, normaliz
 func normalizeFeishuChannelConfigForEnv(configPayload interface{}) map[string]interface{} {
 	config, ok := configPayload.(map[string]interface{})
 	if !ok {
-		return map[string]interface{}{
-			"enabled": true,
-			"accounts": map[string]interface{}{
-				"main": map[string]interface{}{
-					"appId":     "",
-					"appSecret": "",
-				},
-			},
-		}
+		config = map[string]interface{}{}
 	}
 
 	accounts, _ := config["accounts"].(map[string]interface{})
+	normalizedAccounts := make(map[string]interface{}, len(accounts)+1)
+	for accountKey, rawAccount := range accounts {
+		accountMap, ok := rawAccount.(map[string]interface{})
+		if !ok {
+			normalizedAccounts[accountKey] = rawAccount
+			continue
+		}
+		normalizedAccount := make(map[string]interface{}, len(accountMap))
+		for k, v := range accountMap {
+			normalizedAccount[k] = v
+		}
+		if _, ok := normalizedAccount["appId"].(string); !ok {
+			normalizedAccount["appId"] = ""
+		}
+		if _, ok := normalizedAccount["appSecret"].(string); !ok {
+			normalizedAccount["appSecret"] = ""
+		}
+		normalizedAccounts[accountKey] = normalizedAccount
+	}
 
 	var account map[string]interface{}
 	if mainAccount, ok := accounts["main"].(map[string]interface{}); ok {
@@ -1650,16 +1764,29 @@ func normalizeFeishuChannelConfigForEnv(configPayload interface{}) map[string]in
 	if appSecret == "" {
 		appSecret, _ = config["appSecret"].(string)
 	}
-
-	return map[string]interface{}{
-		"enabled": true,
-		"accounts": map[string]interface{}{
-			"main": map[string]interface{}{
-				"appId":     appID,
-				"appSecret": appSecret,
-			},
-		},
+	if _, ok := normalizedAccounts["main"]; !ok {
+		normalizedAccounts["main"] = map[string]interface{}{
+			"appId":     appID,
+			"appSecret": appSecret,
+		}
 	}
+
+	defaultAccount, _ := config["defaultAccount"].(string)
+	if strings.TrimSpace(defaultAccount) == "" {
+		defaultAccount = "main"
+	}
+
+	result := map[string]interface{}{
+		"enabled":        true,
+		"domain":         "feishu",
+		"defaultAccount": defaultAccount,
+		"accounts":       normalizedAccounts,
+	}
+	if requireMention, ok := config["requireMention"].(bool); ok {
+		result["requireMention"] = requireMention
+	}
+
+	return result
 }
 
 func normalizeSlackChannelConfigForEnv(configPayload interface{}) map[string]interface{} {

--- a/backend/internal/services/openclaw_config_service_test.go
+++ b/backend/internal/services/openclaw_config_service_test.go
@@ -49,6 +49,22 @@ func TestRenderCompiledOpenClawPayloadRendersChannelsAsKeyedConfigMap(t *testing
 			model: models.OpenClawConfigResource{
 				ID:           3,
 				ResourceType: OpenClawConfigResourceTypeChannel,
+				ResourceKey:  "feishu-ops",
+				Name:         "Feishu Ops",
+				Version:      1,
+				ContentJSON:  `{"schemaVersion":1,"kind":"channel","format":"channel/feishu-ops@v1","dependsOn":[],"config":{"enabled":true,"domain":"feishu","defaultAccount":"main","accounts":{"main":{"appId":"cli_ops","appSecret":"ops_secret"}}}}`,
+			},
+			envelope: OpenClawConfigEnvelope{
+				SchemaVersion: 1,
+				Kind:          "channel",
+				Format:        "channel/feishu-ops@v1",
+				Config:        json.RawMessage(`{"enabled":true,"domain":"feishu","defaultAccount":"main","accounts":{"main":{"appId":"cli_ops","appSecret":"ops_secret"}}}`),
+			},
+		},
+		{
+			model: models.OpenClawConfigResource{
+				ID:           4,
+				ResourceType: OpenClawConfigResourceTypeChannel,
 				ResourceKey:  "slack",
 				Name:         "Slack",
 				Version:      1,
@@ -63,7 +79,7 @@ func TestRenderCompiledOpenClawPayloadRendersChannelsAsKeyedConfigMap(t *testing
 		},
 		{
 			model: models.OpenClawConfigResource{
-				ID:           4,
+				ID:           5,
 				ResourceType: OpenClawConfigResourceTypeChannel,
 				ResourceKey:  "telegram",
 				Name:         "Telegram",
@@ -95,7 +111,7 @@ func TestRenderCompiledOpenClawPayloadRendersChannelsAsKeyedConfigMap(t *testing
 		},
 		{
 			model: models.OpenClawConfigResource{
-				ID:           5,
+				ID:           7,
 				ResourceType: OpenClawConfigResourceTypeSkill,
 				ResourceKey:  "support-bot",
 				Name:         "Support Bot",
@@ -118,13 +134,13 @@ func TestRenderCompiledOpenClawPayloadRendersChannelsAsKeyedConfigMap(t *testing
 	}
 
 	gotChannels := renderedEnv[OpenClawChannelsEnv]
-	wantChannels := `{"dingtalk-connector":{"allowFrom":["*"],"clientId":"ding-xxxxxxxxxxxxxx","clientSecret":"xxxxxxxxxxxxxxxxxxxxxxx","enabled":true},"feishu":{"accounts":{"main":{"appId":"cli_xxx","appSecret":"xxx"}},"enabled":true},"slack":{"appToken":"xapp-xxx","botToken":"xoxb-xxx","capabilities":{"interactiveReplies":true},"channels":{"#general":{"allow":true}},"enabled":true,"groupPolicy":"allowlist"},"telegram":{"allowFrom":["*"],"botToken":"123456:xxx","dmPolicy":"open","enabled":true},"wecom":{"allowFrom":["*"],"botId":"ww-bot","dmPolicy":"pairing","secret":"wecom-secret"}}`
+	wantChannels := `{"dingtalk-connector":{"allowFrom":["*"],"clientId":"ding-xxxxxxxxxxxxxx","clientSecret":"xxxxxxxxxxxxxxxxxxxxxxx","enabled":true},"feishu":{"accounts":{"default":{"appId":"cli_xxx","appSecret":"xxx","botName":"old-bot","enabled":true},"feishu-ops":{"appId":"cli_ops","appSecret":"ops_secret"},"main":{"appId":"cli_xxx","appSecret":"xxx"}},"defaultAccount":"default","domain":"feishu","enabled":true,"requireMention":true},"slack":{"appToken":"xapp-xxx","botToken":"xoxb-xxx","capabilities":{"interactiveReplies":true},"channels":{"#general":{"allow":true}},"enabled":true,"groupPolicy":"allowlist"},"telegram":{"allowFrom":["*"],"botToken":"123456:xxx","dmPolicy":"open","enabled":true},"wecom":{"allowFrom":["*"],"botId":"ww-bot","dmPolicy":"pairing","secret":"wecom-secret"}}`
 	if gotChannels != wantChannels {
 		t.Fatalf("unexpected channel payload:\nwant: %s\ngot:  %s", wantChannels, gotChannels)
 	}
 
 	gotSkills := renderedEnv[OpenClawSkillsEnv]
-	wantSkills := `{"items":[{"content":{"schemaVersion":1,"kind":"skill","format":"skill/custom@v1","dependsOn":[],"config":{"prompt":"help"}},"id":5,"key":"support-bot","name":"Support Bot","tags":["skill"],"type":"skill","version":1}],"schemaVersion":1}`
+	wantSkills := `{"items":[{"content":{"schemaVersion":1,"kind":"skill","format":"skill/custom@v1","dependsOn":[],"config":{"prompt":"help"}},"id":7,"key":"support-bot","name":"Support Bot","tags":["skill"],"type":"skill","version":1}],"schemaVersion":1}`
 	if gotSkills != wantSkills {
 		t.Fatalf("unexpected skill payload:\nwant: %s\ngot:  %s", wantSkills, gotSkills)
 	}
@@ -153,6 +169,61 @@ func TestRuntimeBootstrapEnvValuesAddsHermesAndRuntimeAliases(t *testing.T) {
 	}
 	if !strings.Contains(got[RuntimeBootstrapManifestEnv], RuntimeChannelsEnv) {
 		t.Fatalf("expected runtime manifest alias to reference runtime env names, got %s", got[RuntimeBootstrapManifestEnv])
+	}
+}
+
+func TestOpenClawChannelEnvKeyUsesProviderKeyForResourceAliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		resourceKey string
+		config      map[string]interface{}
+		want        string
+	}{
+		{
+			name:        "feishu resource alias",
+			resourceKey: "feishu-2",
+			config: map[string]interface{}{
+				"domain": "feishu",
+				"accounts": map[string]interface{}{
+					"main": map[string]interface{}{
+						"appId":     "cli_xxx",
+						"appSecret": "secret",
+					},
+				},
+			},
+			want: "feishu",
+		},
+		{
+			name:        "dingtalk resource alias",
+			resourceKey: "dingtalk-2",
+			config: map[string]interface{}{
+				"clientId":     "ding_xxx",
+				"clientSecret": "secret",
+			},
+			want: "dingtalk-connector",
+		},
+		{
+			name:        "wecom resource alias",
+			resourceKey: "wecom-2",
+			config: map[string]interface{}{
+				"botId":  "ww-bot",
+				"secret": "secret",
+			},
+			want: "wecom",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := openClawChannelEnvKey(tt.resourceKey, tt.config); got != tt.want {
+				t.Fatalf("unexpected env key: want %s, got %s", tt.want, got)
+			}
+		})
 	}
 }
 

--- a/docs/hermes-runtime-agent-development.md
+++ b/docs/hermes-runtime-agent-development.md
@@ -188,7 +188,7 @@ Do not print channel tokens, secrets, webhooks, bootstrap tokens, session tokens
 
 Hermes agent behavior:
 
-1. Use the top-level key as the channel ID, for example `feishu`, `telegram`, `slack`, or `dingtalk-connector`.
+1. Use the top-level key as the runtime channel ID, for example `feishu`, `telegram`, `slack`, or `dingtalk-connector`. Resource-specific Feishu/Lark keys such as `feishu-ops` must be folded into the `feishu.accounts` map before injection.
 2. Skip channels with `enabled=false`, but keep their config on disk so future updates can re-enable them.
 3. Convert channel config into Hermes-native notification or messaging configuration. A reasonable default path is `/config/.hermes/channels.json`, unless Hermes has a native config location.
 4. Preserve unknown fields so future ClawManager extensions are not lost.

--- a/frontend/src/lib/openclawChannelTemplates.ts
+++ b/frontend/src/lib/openclawChannelTemplates.ts
@@ -65,6 +65,8 @@ export const OPENCLAW_CHANNEL_TEMPLATES: OpenClawChannelTemplate[] = [
   }),
   createChannelTemplate('feishu', 'Feishu / Lark', 'Feishu or Lark plugin channel with account-aware defaults.', 'plugin', {
     enabled: true,
+    domain: 'feishu',
+    defaultAccount: 'main',
     accounts: {
       main: {
         appId: '',

--- a/frontend/src/pages/openclaw/OpenClawConfigCenterPage.tsx
+++ b/frontend/src/pages/openclaw/OpenClawConfigCenterPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import UserLayout from "../../components/UserLayout";
 import { useI18n } from "../../contexts/I18nContext";
@@ -1034,6 +1034,35 @@ const OpenClawConfigCenterPage: React.FC = () => {
     () => findOpenClawChannelTemplate(selectedChannelTemplateId),
     [selectedChannelTemplateId],
   );
+  const buildUniqueResourceKey = useCallback(
+    (baseKey: string): string => {
+      const trimmedBaseKey = baseKey.trim();
+      if (!trimmedBaseKey) {
+        return "";
+      }
+
+      const existingKeys = new Set(
+        resources
+          .filter(
+            (item) =>
+              item.resource_type === "channel" && item.id !== selectedResourceId,
+          )
+          .map((item) => item.resource_key.trim().toLowerCase()),
+      );
+      if (!existingKeys.has(trimmedBaseKey.toLowerCase())) {
+        return trimmedBaseKey;
+      }
+
+      let suffix = 2;
+      let candidate = `${trimmedBaseKey}-${suffix}`;
+      while (existingKeys.has(candidate.toLowerCase())) {
+        suffix += 1;
+        candidate = `${trimmedBaseKey}-${suffix}`;
+      }
+      return candidate;
+    },
+    [resources, selectedResourceId],
+  );
   const supportedChannelEditorId = useMemo(
     () =>
       resourceForm.resource_type === "channel"
@@ -1370,7 +1399,9 @@ const OpenClawConfigCenterPage: React.FC = () => {
     setResourceForm((current) => ({
       ...current,
       resource_type: "channel",
-      resource_key: current.resource_key.trim() || template.resourceKey,
+      resource_key:
+        current.resource_key.trim() ||
+        buildUniqueResourceKey(template.resourceKey),
       name: current.name.trim() || templateLabel,
       description: current.description.trim() || templateDescription,
       tagsText: mergeTagText(current.tagsText, template.tags),


### PR DESCRIPTION
- Support multiple OpenClaw channel resources and fix alias injection
- Disable Webtop/KasmVNC bidirectional clipboard sync by default to reduce accidental paste during remote desktop input
- Derive desktop runtime /dev/shm defaults from instance memory: 1G for 4G, 2G for 8G, and 4G for 12G+
- Preserve explicit SHM_SIZE_GB overrides and keep shell runtime behavior unchanged
- Add tests for openclaw/hermes clipboard policy and /dev/shm default selection
