### PR TITLE
feat: manage instances with Deployments

### DIFF
--- a/backend/deployments/k8s/clawreef-incluster.yaml
+++ b/backend/deployments/k8s/clawreef-incluster.yaml
@@ -442,6 +442,13 @@ data:
       UNIQUE KEY uk_openclaw_bundle_skill (bundle_id, skill_id),
       INDEX idx_openclaw_bundle_skill_bundle (bundle_id, sort_order)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  023_normalize_runtime_config_mounts.sql: |
+    USE clawreef;
+    UPDATE instances
+    SET mount_path = '/config',
+        updated_at = CURRENT_TIMESTAMP
+    WHERE type IN ('openclaw', 'ubuntu', 'webtop', 'hermes')
+      AND mount_path IN ('/data', '/home/user/data', '/config/.hermes');
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/backend/internal/db/migrations/023_normalize_runtime_config_mounts.sql
+++ b/backend/internal/db/migrations/023_normalize_runtime_config_mounts.sql
@@ -1,0 +1,5 @@
+UPDATE instances
+SET mount_path = '/config',
+    updated_at = CURRENT_TIMESTAMP
+WHERE type IN ('openclaw', 'ubuntu', 'webtop', 'hermes')
+  AND mount_path IN ('/data', '/home/user/data', '/config/.hermes');

--- a/backend/internal/services/instance_runtime.go
+++ b/backend/internal/services/instance_runtime.go
@@ -61,7 +61,7 @@ func buildRuntimeConfig(instanceType, osType, osVersion string, registry, tag *s
 	case "hermes":
 		config.Image = defaultSystemImageSettings["hermes"]
 		config.Port = 3001
-		config.MountPath = "/config/.hermes"
+		config.MountPath = "/config"
 		config.Env = defaultWebtopDesktopEnv("Hermes Runtime")
 	case "openclaw":
 		config.MountPath = "/config"
@@ -95,7 +95,7 @@ func defaultMountPathForInstanceType(instanceType string) string {
 	case "ubuntu", "webtop", "openclaw":
 		return "/config"
 	case "hermes":
-		return "/config/.hermes"
+		return "/config"
 	default:
 		return "/home/user/data"
 	}

--- a/backend/internal/services/instance_runtime_test.go
+++ b/backend/internal/services/instance_runtime_test.go
@@ -28,8 +28,8 @@ func TestBuildRuntimeConfig_HermesUsesWebtopDefaults(t *testing.T) {
 	if config.Port != 3001 {
 		t.Fatalf("expected Hermes port 3001, got %d", config.Port)
 	}
-	if config.MountPath != "/config/.hermes" {
-		t.Fatalf("expected Hermes mount path /config/.hermes, got %q", config.MountPath)
+	if config.MountPath != "/config" {
+		t.Fatalf("expected Hermes mount path /config, got %q", config.MountPath)
 	}
 	if config.Env["SUBFOLDER"] != "/" {
 		t.Fatalf("expected Hermes default SUBFOLDER /, got %q", config.Env["SUBFOLDER"])

--- a/backend/internal/services/instance_service.go
+++ b/backend/internal/services/instance_service.go
@@ -499,6 +499,7 @@ func (s *instanceService) Create(userID int, req CreateInstanceRequest) (*models
 		EnvFromSecretNames:   envFromSecretNames,
 		ExtraPVCMounts:       extraPVCMounts,
 		ConfigMapFileMounts:  configMapFileMounts,
+		VolumeInitScripts:    runtimeVolumeInitScripts(instance.Type, runtimeConfig.MountPath),
 		FSGroup:              fsGroup,
 		VolumeOwnershipFixes: volumeOwnershipFixes,
 		SHMSizeGB:            shmSizeGB,
@@ -642,6 +643,8 @@ func (s *instanceService) Start(instanceID int) error {
 		return fmt.Errorf("failed to build instance agent config: %w", err)
 	}
 	runtimeConfig := buildRuntimeConfig(instance.Type, instance.OSType, instance.OSVersion, instance.ImageRegistry, instance.ImageTag)
+	mountPath := persistentVolumeMountPath(instance)
+	instance.MountPath = mountPath
 	extraEnv, err := buildInstancePodEnv(instance, runtimeConfig.Env, gatewayEnv, agentEnv)
 	if err != nil {
 		return fmt.Errorf("failed to resolve instance environment: %w", err)
@@ -673,11 +676,12 @@ func (s *instanceService) Start(instanceID int) error {
 		GPUEnabled:         instance.GPUEnabled,
 		GPUCount:           instance.GPUCount,
 		Image:              runtimeConfig.Image,
-		MountPath:          instance.MountPath,
+		MountPath:          mountPath,
 		ContainerPort:      runtimeConfig.Port,
 		ImagePullPolicy:    corev1.PullPolicy(defaultImagePullPolicy()),
 		ExtraEnv:           extraEnv,
 		EnvFromSecretNames: []string{bootstrapSecretName},
+		VolumeInitScripts:  runtimeVolumeInitScripts(instance.Type, mountPath),
 		SHMSizeGB:          shmSizeGB,
 		SecurityMode:       s.securityModeForInstance(instance.Type),
 	}
@@ -856,10 +860,51 @@ func managedRuntimePersistentDir(instance *models.Instance) string {
 	if strings.EqualFold(instance.Type, "hermes") {
 		return "/config/.hermes"
 	}
+	return persistentVolumeMountPath(instance)
+}
+
+func persistentVolumeMountPath(instance *models.Instance) string {
+	if instance == nil {
+		return "/config"
+	}
+	if defaultPath := defaultMountPathForInstanceType(instance.Type); defaultPath == "/config" {
+		return defaultPath
+	}
 	if strings.TrimSpace(instance.MountPath) != "" {
 		return strings.TrimSpace(instance.MountPath)
 	}
 	return defaultMountPathForInstanceType(instance.Type)
+}
+
+func runtimeVolumeInitScripts(instanceType, mountPath string) []k8s.VolumeInitScript {
+	if !strings.EqualFold(strings.TrimSpace(instanceType), "hermes") || strings.TrimSpace(mountPath) != "/config" {
+		return nil
+	}
+	return []k8s.VolumeInitScript{
+		{
+			Name:      "data",
+			MountPath: "/config",
+			Script: `set -eu
+base="${CLAWMANAGER_VOLUME_PATH:-/config}"
+target="$base/.hermes"
+if [ ! -d "$target" ]; then
+  legacy_found=0
+  for name in hermes-agent skills channels.json session.json bootstrap inventory.json; do
+    if [ -e "$base/$name" ]; then legacy_found=1; fi
+  done
+  mkdir -p "$target"
+  if [ "$legacy_found" = "1" ]; then
+    for entry in "$base"/* "$base"/.[!.]* "$base"/..?*; do
+      [ -e "$entry" ] || continue
+      name="${entry##*/}"
+      case "$name" in .|..|.hermes|Desktop|Downloads|lost+found) continue;; esac
+      mv "$entry" "$target"/
+    done
+  fi
+fi
+chown -R 1000:1000 "$target" || true`,
+		},
+	}
 }
 
 func (s *instanceService) resolveGatewayModelInjection() (*gatewayModelInjection, error) {

--- a/backend/internal/services/instance_service.go
+++ b/backend/internal/services/instance_service.go
@@ -1087,6 +1087,19 @@ func (s *instanceService) cleanupOrphanedResources(ctx context.Context, userID, 
 		fmt.Printf("Namespace %s has %d other instance(s), will not delete namespace\n", namespace, otheInstanceCount)
 	}
 
+	deployments, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("instance-id=%s", instanceLabel),
+	})
+	if err == nil && len(deployments.Items) > 0 {
+		for _, deployment := range deployments.Items {
+			fmt.Printf("Deleting orphaned Deployment %s\n", deployment.Name)
+			propagation := metav1.DeletePropagationForeground
+			client.AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{
+				PropagationPolicy: &propagation,
+			})
+		}
+	}
+
 	// List and delete ConfigMaps with instance label
 	configMaps, err := client.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("instance-id=%s", instanceLabel),
@@ -1127,6 +1140,34 @@ func (s *instanceService) cleanupOrphanedResources(ctx context.Context, userID, 
 func (s *instanceService) cleanupOrphanedResourcesByUser(ctx context.Context, userID int) {
 	namespace := s.pvcService.GetClient().GetNamespace(userID)
 	client := s.pvcService.GetClient().Clientset
+
+	deployments, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "managed-by=clawreef",
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to list deployments in namespace %s: %v\n", namespace, err)
+	} else {
+		for _, deployment := range deployments.Items {
+			instanceIDStr := deployment.Labels["instance-id"]
+			if instanceIDStr == "" {
+				continue
+			}
+
+			instanceID := 0
+			fmt.Sscanf(instanceIDStr, "%d", &instanceID)
+
+			instance, err := s.instanceRepo.GetByID(instanceID)
+			if err != nil || instance == nil {
+				fmt.Printf("Found orphaned deployment %s (instance-id: %s), deleting...\n", deployment.Name, instanceIDStr)
+				propagation := metav1.DeletePropagationForeground
+				if err := client.AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{
+					PropagationPolicy: &propagation,
+				}); err != nil {
+					fmt.Printf("Warning: failed to delete orphaned deployment %s: %v\n", deployment.Name, err)
+				}
+			}
+		}
+	}
 
 	// Get all pods in the namespace with clawreef label
 	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
@@ -1322,6 +1363,28 @@ func (s *instanceService) ForceSyncInstance(instanceID int) error {
 
 	if err != nil {
 		fmt.Printf("Instance %d: Pod not found in K8s: %v\n", instanceID, err)
+
+		deploymentExists, deploymentErr := s.podService.DeploymentExists(ctx, instance.UserID, instance.ID)
+		if deploymentErr != nil {
+			fmt.Printf("Instance %d: failed to check deployment while pod was missing: %v\n", instanceID, deploymentErr)
+		}
+		if deploymentExists {
+			fmt.Printf("Instance %d: Deployment exists but no pod is available yet, updating to creating\n", instanceID)
+			if instance.Status != "creating" {
+				instance.Status = "creating"
+				instance.PodName = nil
+				instance.PodNamespace = nil
+				instance.PodIP = nil
+				instance.UpdatedAt = time.Now()
+
+				if err := s.instanceRepo.Update(instance); err != nil {
+					return fmt.Errorf("failed to update instance status: %w", err)
+				}
+
+				GetHub().BroadcastInstanceStatus(instance.UserID, instance)
+			}
+			return nil
+		}
 
 		// If instance thinks it's running or creating but pod doesn't exist, update to stopped
 		if instance.Status == "running" || instance.Status == "creating" {

--- a/backend/internal/services/instance_service_test.go
+++ b/backend/internal/services/instance_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 
 	"clawreef/internal/models"
@@ -128,6 +129,43 @@ func TestBuildAgentEnvInjectsHermesAgentConfig(t *testing.T) {
 	}
 	if env["CLAWMANAGER_AGENT_DISK_LIMIT_BYTES"] != "21474836480" {
 		t.Fatalf("expected Hermes disk limit bytes to be injected, got %q", env["CLAWMANAGER_AGENT_DISK_LIMIT_BYTES"])
+	}
+}
+
+func TestPersistentVolumeMountPathNormalizesManagedDesktopRuntimes(t *testing.T) {
+	for _, instanceType := range []string{"openclaw", "ubuntu", "webtop", "hermes"} {
+		t.Run(instanceType, func(t *testing.T) {
+			got := persistentVolumeMountPath(&models.Instance{
+				Type:      instanceType,
+				MountPath: "/data",
+			})
+			if got != "/config" {
+				t.Fatalf("expected %s PVC mount path /config, got %q", instanceType, got)
+			}
+		})
+	}
+}
+
+func TestManagedRuntimePersistentDirKeepsHermesSubdirectory(t *testing.T) {
+	got := managedRuntimePersistentDir(&models.Instance{
+		Type:      "hermes",
+		MountPath: "/config",
+	})
+	if got != "/config/.hermes" {
+		t.Fatalf("expected Hermes persistent dir /config/.hermes, got %q", got)
+	}
+}
+
+func TestRuntimeVolumeInitScriptsAddsHermesLayoutMigration(t *testing.T) {
+	scripts := runtimeVolumeInitScripts("hermes", "/config")
+	if len(scripts) != 1 {
+		t.Fatalf("expected one Hermes volume init script, got %d", len(scripts))
+	}
+	if scripts[0].Name != "data" || scripts[0].MountPath != "/config" {
+		t.Fatalf("unexpected Hermes volume init script: %#v", scripts[0])
+	}
+	if !strings.Contains(scripts[0].Script, `target="$base/.hermes"`) {
+		t.Fatalf("expected Hermes init script to target /config/.hermes, got %s", scripts[0].Script)
 	}
 }
 

--- a/backend/internal/services/k8s/cleanup_service.go
+++ b/backend/internal/services/k8s/cleanup_service.go
@@ -47,12 +47,17 @@ func (s *CleanupService) DeleteAllInstanceResources(ctx context.Context, userID,
 	for _, namespace := range namespaces {
 		fmt.Printf("Deleting resources for instance %d in namespace %s\n", instanceID, namespace)
 
-		// 1. Delete all Pods with matching instance-id label
+		// 1. Delete all Deployments first so managed Pods are not recreated.
+		if err := s.deleteAllDeployments(ctx, namespace, instanceLabel); err != nil {
+			fmt.Printf("Warning: error deleting deployments: %v\n", err)
+		}
+
+		// 2. Delete all Pods with matching instance-id label
 		if err := s.deleteAllPods(ctx, namespace, instanceLabel); err != nil {
 			fmt.Printf("Warning: error deleting pods: %v\n", err)
 		}
 
-		// 2. Delete all PVCs with matching instance-id label
+		// 3. Delete all PVCs with matching instance-id label
 		if err := s.deleteAllPVCs(ctx, namespace, instanceLabel); err != nil {
 			fmt.Printf("Warning: error deleting PVCs: %v\n", err)
 		}
@@ -78,7 +83,7 @@ func (s *CleanupService) DeleteAllInstanceResources(ctx context.Context, userID,
 		}
 	}
 
-	// 3. Delete all PVs associated with this instance (PVs are not namespaced)
+	// 8. Delete all PVs associated with this instance (PVs are not namespaced)
 	if err := s.deleteAllPVs(ctx, userID, instanceID); err != nil {
 		fmt.Printf("Warning: error deleting PVs: %v\n", err)
 	}
@@ -103,6 +108,14 @@ func (s *CleanupService) findNamespacesWithInstance(ctx context.Context, instanc
 
 	var result []string
 	for _, ns := range namespaces.Items {
+		deployments, err := s.client.Clientset.AppsV1().Deployments(ns.Name).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("instance-id=%s,managed-by=clawreef", instanceLabel),
+		})
+		if err == nil && len(deployments.Items) > 0 {
+			result = append(result, ns.Name)
+			continue
+		}
+
 		// Check if this namespace has any pods for this instance
 		pods, err := s.client.Clientset.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("instance-id=%s,managed-by=clawreef", instanceLabel),
@@ -130,6 +143,33 @@ func (s *CleanupService) findNamespacesWithInstance(ctx context.Context, instanc
 	}
 
 	return result, nil
+}
+
+// deleteAllDeployments deletes all deployments with matching instance-id label.
+func (s *CleanupService) deleteAllDeployments(ctx context.Context, namespace, instanceLabel string) error {
+	deployments, err := s.client.Clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("instance-id=%s,managed-by=clawreef", instanceLabel),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list deployments: %w", err)
+	}
+
+	if len(deployments.Items) == 0 {
+		fmt.Printf("No deployments found for instance %s\n", instanceLabel)
+		return nil
+	}
+
+	for _, deployment := range deployments.Items {
+		fmt.Printf("Deleting deployment: %s\n", deployment.Name)
+		propagation := metav1.DeletePropagationForeground
+		if err := s.client.Clientset.AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{
+			PropagationPolicy: &propagation,
+		}); err != nil && !errors.IsNotFound(err) {
+			fmt.Printf("Warning: failed to delete deployment %s: %v\n", deployment.Name, err)
+		}
+	}
+
+	return nil
 }
 
 // deleteAllPods deletes all pods with matching instance-id label
@@ -306,6 +346,14 @@ func (s *CleanupService) WaitForResourceDeletion(ctx context.Context, namespaces
 			allDeleted := true
 
 			for _, namespace := range namespaces {
+				deployments, err := s.client.Clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("instance-id=%s,managed-by=clawreef", instanceLabel),
+				})
+				if err == nil && len(deployments.Items) > 0 {
+					allDeleted = false
+					fmt.Printf("  Still waiting: %d deployment(s) in %s\n", len(deployments.Items), namespace)
+				}
+
 				// Check pods
 				pods, err := s.client.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("instance-id=%s,managed-by=clawreef", instanceLabel),

--- a/backend/internal/services/k8s/client.go
+++ b/backend/internal/services/k8s/client.go
@@ -235,6 +235,11 @@ func (c *Client) GetPodName(instanceID int, instanceName string) string {
 	return sanitizeK8sName(fmt.Sprintf("clawreef-%d-%s", instanceID, instanceName))
 }
 
+// GetDeploymentName returns the deployment name for an instance.
+func (c *Client) GetDeploymentName(instanceID int, instanceName string) string {
+	return sanitizeK8sName(fmt.Sprintf("clawreef-%d-%s", instanceID, instanceName))
+}
+
 // GetPVCName returns the PVC name for an instance
 func (c *Client) GetPVCName(instanceID int) string {
 	return sanitizeK8sName(fmt.Sprintf("clawreef-%d-pvc", instanceID))

--- a/backend/internal/services/k8s/pod_service.go
+++ b/backend/internal/services/k8s/pod_service.go
@@ -59,6 +59,7 @@ type PodConfig struct {
 	EnvFromSecretNames   []string
 	ExtraPVCMounts       []PVCMount
 	ConfigMapFileMounts  []ConfigMapFileMount
+	VolumeInitScripts    []VolumeInitScript
 	FSGroup              *int64
 	VolumeOwnershipFixes []VolumeOwnershipFix
 	SHMSizeGB            int
@@ -86,6 +87,12 @@ type VolumeOwnershipFix struct {
 	MountPath string
 	UID       int64
 	GID       int64
+}
+
+type VolumeInitScript struct {
+	Name      string
+	MountPath string
+	Script    string
 }
 
 // CreatePod creates a new pod for an instance
@@ -263,6 +270,13 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 		})
 	}
 
+	for index, initScript := range config.VolumeInitScripts {
+		if initScript.Name == "" || initScript.MountPath == "" || initScript.Script == "" {
+			continue
+		}
+		pod.Spec.InitContainers = append(pod.Spec.InitContainers, buildVolumeInitScriptContainer(index, config.Image, pullPolicy, initScript))
+	}
+
 	for index, fix := range config.VolumeOwnershipFixes {
 		if fix.Name == "" || fix.MountPath == "" || fix.UID < 0 || fix.GID < 0 {
 			continue
@@ -423,6 +437,33 @@ fi`,
 			{
 				Name:      fix.Name,
 				MountPath: fix.MountPath,
+			},
+		},
+	}
+}
+
+func buildVolumeInitScriptContainer(index int, image string, pullPolicy corev1.PullPolicy, initScript VolumeInitScript) corev1.Container {
+	rootUser := int64(0)
+	return corev1.Container{
+		Name:            fmt.Sprintf("init-volume-layout-%d", index+1),
+		Image:           image,
+		ImagePullPolicy: pullPolicy,
+		Command: []string{
+			"sh",
+			"-c",
+			initScript.Script,
+		},
+		Env: []corev1.EnvVar{
+			{Name: "CLAWMANAGER_VOLUME_PATH", Value: initScript.MountPath},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:  &rootUser,
+			RunAsGroup: &rootUser,
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      initScript.Name,
+				MountPath: initScript.MountPath,
 			},
 		},
 	}

--- a/backend/internal/services/k8s/pod_service.go
+++ b/backend/internal/services/k8s/pod_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -20,8 +21,9 @@ type PodService struct {
 type PodSecurityMode string
 
 const (
-	podDeletionPollInterval = 500 * time.Millisecond
-	podDeletionTimeout      = 60 * time.Second
+	podDeletionPollInterval   = 500 * time.Millisecond
+	podDeletionTimeout        = 60 * time.Second
+	deploymentDeletionTimeout = 60 * time.Second
 
 	PodSecurityDefault        PodSecurityMode = "default"
 	PodSecurityChromiumCompat PodSecurityMode = "chromium-compat"
@@ -95,13 +97,15 @@ type VolumeInitScript struct {
 	Script    string
 }
 
-// CreatePod creates a new pod for an instance
+// CreatePod creates a single-replica Deployment for an instance and returns the
+// pod template that will be used for managed Pods. Callers should use GetPod to
+// resolve the current real Pod after the Deployment controller creates it.
 func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.Pod, error) {
 	if s.client == nil {
 		return nil, fmt.Errorf("k8s client not initialized")
 	}
 
-	podName := s.client.GetPodName(config.InstanceID, config.InstanceName)
+	deploymentName := s.client.GetDeploymentName(config.InstanceID, config.InstanceName)
 	namespace := s.client.GetNamespace(config.UserID)
 	pvcName := s.client.GetPVCName(config.InstanceID)
 	runtimeType := normalizePodRuntimeType(config.RuntimeType)
@@ -142,23 +146,25 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 		annotations["container.apparmor.security.beta.kubernetes.io/desktop"] = "unconfined"
 	}
 
+	labels := map[string]string{
+		"app":           "clawreef",
+		"instance-id":   fmt.Sprintf("%d", config.InstanceID),
+		"instance-name": config.InstanceName,
+		"user-id":       fmt.Sprintf("%d", config.UserID),
+		"instance-type": config.Type,
+		"runtime-type":  runtimeType,
+		"managed-by":    "clawreef",
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        podName,
+			Name:        deploymentName,
 			Namespace:   namespace,
-			Annotations: annotations,
-			Labels: map[string]string{
-				"app":           "clawreef",
-				"instance-id":   fmt.Sprintf("%d", config.InstanceID),
-				"instance-name": config.InstanceName,
-				"user-id":       fmt.Sprintf("%d", config.UserID),
-				"instance-type": config.Type,
-				"runtime-type":  runtimeType,
-				"managed-by":    "clawreef",
-			},
+			Annotations: copyStringMap(annotations),
+			Labels:      copyStringMap(labels),
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:   corev1.RestartPolicyNever,
+			RestartPolicy:   corev1.RestartPolicyAlways,
 			SecurityContext: buildPodSecurityContext(config.FSGroup),
 			Containers: []corev1.Container{
 				{
@@ -341,36 +347,55 @@ func (s *PodService) CreatePod(ctx context.Context, config PodConfig) (*corev1.P
 		})
 	}
 
-	createdPod, err := s.client.Clientset.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
-	if err != nil {
-		// Check if pod already exists
-		if errors.IsAlreadyExists(err) {
-			// Try to get the existing pod with the same name. It may still be terminating.
-			existingPod, getErr := s.client.Clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
-			if getErr == nil && existingPod != nil {
-				if existingPod.DeletionTimestamp == nil {
-					deleteErr := s.client.Clientset.CoreV1().Pods(namespace).Delete(ctx, existingPod.Name, metav1.DeleteOptions{})
-					if deleteErr != nil && !errors.IsNotFound(deleteErr) {
-						return nil, fmt.Errorf("failed to delete existing pod %s: %w", existingPod.Name, deleteErr)
-					}
-				}
-
-				if waitErr := s.waitForPodDeletion(ctx, namespace, existingPod.Name); waitErr != nil {
-					return nil, fmt.Errorf("failed waiting for pod deletion %s: %w", existingPod.Name, waitErr)
-				}
-
-				// Retry creation
-				createdPod, err = s.client.Clientset.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
-				if err != nil {
-					return nil, fmt.Errorf("failed to create pod after deletion %s: %w", podName, err)
-				}
-				return createdPod, nil
-			}
-		}
-		return nil, fmt.Errorf("failed to create pod %s: %w", podName, err)
+	replicas := int32(1)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: namespace,
+			Labels:    copyStringMap(labels),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":         "clawreef",
+					"instance-id": fmt.Sprintf("%d", config.InstanceID),
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: copyStringMap(annotations),
+					Labels:      copyStringMap(labels),
+				},
+				Spec: pod.Spec,
+			},
+		},
 	}
 
-	return createdPod, nil
+	createdDeployment, err := s.client.Clientset.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			existingDeployment, getErr := s.client.Clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+			if getErr == nil && existingDeployment != nil {
+				if existingDeployment.DeletionTimestamp == nil {
+					return podFromDeployment(existingDeployment), nil
+				}
+
+				if waitErr := s.waitForDeploymentDeletion(ctx, namespace, existingDeployment.Name); waitErr != nil {
+					return nil, fmt.Errorf("failed waiting for deployment deletion %s: %w", existingDeployment.Name, waitErr)
+				}
+
+				createdDeployment, err = s.client.Clientset.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+				if err != nil {
+					return nil, fmt.Errorf("failed to create deployment after deletion %s: %w", deploymentName, err)
+				}
+				return podFromDeployment(createdDeployment), nil
+			}
+		}
+		return nil, fmt.Errorf("failed to create deployment %s: %w", deploymentName, err)
+	}
+
+	return podFromDeployment(createdDeployment), nil
 }
 
 func buildPodSecurityContext(fsGroup *int64) *corev1.PodSecurityContext {
@@ -480,6 +505,32 @@ func intstrFromInt32(port int32) intstr.IntOrString {
 	return intstr.FromInt32(port)
 }
 
+func podFromDeployment(deployment *appsv1.Deployment) *corev1.Pod {
+	if deployment == nil {
+		return nil
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        deployment.Name,
+			Namespace:   deployment.Namespace,
+			Labels:      copyStringMap(deployment.Spec.Template.Labels),
+			Annotations: copyStringMap(deployment.Spec.Template.Annotations),
+		},
+		Spec: deployment.Spec.Template.Spec,
+	}
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
+}
+
 // GetPod gets a pod by instance ID
 func (s *PodService) GetPod(ctx context.Context, userID, instanceID int) (*corev1.Pod, error) {
 	if s.client == nil {
@@ -501,31 +552,113 @@ func (s *PodService) GetPod(ctx context.Context, userID, instanceID int) (*corev
 		return nil, fmt.Errorf("pod not found for instance %d", instanceID)
 	}
 
-	return &pods.Items[0], nil
+	return selectCurrentPod(pods.Items), nil
 }
 
-// DeletePod deletes a pod
+func selectCurrentPod(pods []corev1.Pod) *corev1.Pod {
+	var selected *corev1.Pod
+	selectedRank := -1
+	for i := range pods {
+		pod := &pods[i]
+		rank := podSelectionRank(pod)
+		if rank > selectedRank {
+			selected = pod
+			selectedRank = rank
+		}
+	}
+	if selected != nil {
+		return selected
+	}
+	return &pods[0]
+}
+
+func podSelectionRank(pod *corev1.Pod) int {
+	if pod == nil {
+		return 0
+	}
+	if pod.DeletionTimestamp != nil {
+		return 1
+	}
+	switch pod.Status.Phase {
+	case corev1.PodRunning:
+		if isPodReadyForSelection(pod) {
+			return 6
+		}
+		return 5
+	case corev1.PodPending:
+		return 4
+	case corev1.PodUnknown:
+		return 3
+	case corev1.PodSucceeded:
+		return 2
+	case corev1.PodFailed:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func isPodReadyForSelection(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// DeletePod deletes the instance Deployment so managed Pods are not recreated.
 func (s *PodService) DeletePod(ctx context.Context, userID, instanceID int) error {
+	return s.DeleteDeployment(ctx, userID, instanceID)
+}
+
+// DeleteDeployment deletes all Deployments for an instance.
+func (s *PodService) DeleteDeployment(ctx context.Context, userID, instanceID int) error {
 	if s.client == nil {
 		return fmt.Errorf("k8s client not initialized")
 	}
 
-	pod, err := s.GetPod(ctx, userID, instanceID)
+	namespace := s.client.GetNamespace(userID)
+	selector := fmt.Sprintf("instance-id=%d", instanceID)
+
+	deployments, err := s.client.Clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
 	if err != nil {
-		// Pod doesn't exist, nothing to delete
 		if isNotFoundError(err) {
 			return nil
 		}
-		return err
+		return fmt.Errorf("failed to list deployments: %w", err)
 	}
 
-	err = s.client.Clientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete pod %s: %w", pod.Name, err)
+	for _, deployment := range deployments.Items {
+		propagation := metav1.DeletePropagationForeground
+		err = s.client.Clientset.AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, metav1.DeleteOptions{
+			PropagationPolicy: &propagation,
+		})
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete deployment %s: %w", deployment.Name, err)
+		}
+
+		if err := s.waitForDeploymentDeletion(ctx, namespace, deployment.Name); err != nil {
+			return fmt.Errorf("failed waiting for deployment %s to be deleted: %w", deployment.Name, err)
+		}
 	}
 
-	if err := s.waitForPodDeletion(ctx, pod.Namespace, pod.Name); err != nil {
-		return fmt.Errorf("failed waiting for pod %s to be deleted: %w", pod.Name, err)
+	pods, err := s.client.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list pods after deployment deletion: %w", err)
+	}
+	for _, pod := range pods.Items {
+		err = s.client.Clientset.CoreV1().Pods(namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete pod %s: %w", pod.Name, err)
+		}
+		if err := s.waitForPodDeletion(ctx, namespace, pod.Name); err != nil {
+			return fmt.Errorf("failed waiting for pod %s to be deleted: %w", pod.Name, err)
+		}
 	}
 
 	return nil
@@ -559,6 +692,27 @@ func (s *PodService) PodExists(ctx context.Context, userID, instanceID int) (boo
 		return false, err
 	}
 	return true, nil
+}
+
+// DeploymentExists checks if an instance Deployment exists.
+func (s *PodService) DeploymentExists(ctx context.Context, userID, instanceID int) (bool, error) {
+	if s.client == nil {
+		return false, fmt.Errorf("k8s client not initialized")
+	}
+
+	namespace := s.client.GetNamespace(userID)
+	selector := fmt.Sprintf("instance-id=%d", instanceID)
+	deployments, err := s.client.Clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to list deployments: %w", err)
+	}
+
+	return len(deployments.Items) > 0, nil
 }
 
 func isNotFoundError(err error) bool {
@@ -601,6 +755,33 @@ func (s *PodService) waitForPodDeletion(ctx context.Context, namespace, podName 
 				return ctx.Err()
 			}
 			return fmt.Errorf("timed out waiting for pod %s deletion", podName)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *PodService) waitForDeploymentDeletion(ctx context.Context, namespace, deploymentName string) error {
+	waitCtx, cancel := context.WithTimeout(ctx, deploymentDeletionTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(podDeletionPollInterval)
+	defer ticker.Stop()
+
+	for {
+		_, err := s.client.Clientset.AppsV1().Deployments(namespace).Get(waitCtx, deploymentName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to check deployment %s: %w", deploymentName, err)
+		}
+
+		select {
+		case <-waitCtx.Done():
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("timed out waiting for deployment %s deletion", deploymentName)
 		case <-ticker.C:
 		}
 	}

--- a/backend/internal/services/k8s/pod_service_test.go
+++ b/backend/internal/services/k8s/pod_service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -63,6 +65,14 @@ func TestCreatePodAppliesSecurityModes(t *testing.T) {
 		t.Fatalf("CreatePod returned error: %v", err)
 	}
 
+	deployment := mustGetDeployment(t, service, "clawreef-user-7", "clawreef-42-openclaw-test")
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 1 {
+		t.Fatalf("expected single-replica deployment, got %#v", deployment.Spec.Replicas)
+	}
+	if deployment.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyAlways {
+		t.Fatalf("expected deployment-managed pod restartPolicy Always, got %s", deployment.Spec.Template.Spec.RestartPolicy)
+	}
+
 	container := pod.Spec.Containers[0]
 	if container.SecurityContext == nil {
 		t.Fatalf("expected chromium compat security context")
@@ -105,6 +115,11 @@ func TestCreatePodShellRuntimeSkipsDesktopNetworkProbes(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreatePod returned error: %v", err)
+	}
+
+	deployment := mustGetDeployment(t, service, "clawreef-user-7", "clawreef-43-shell-test")
+	if len(deployment.Spec.Template.Spec.Containers[0].Ports) != 0 {
+		t.Fatalf("expected shell deployment template to skip desktop ports")
 	}
 
 	container := pod.Spec.Containers[0]
@@ -158,6 +173,11 @@ func TestCreatePodAppliesExtraPVCMountsAndSecretEnv(t *testing.T) {
 		t.Fatalf("CreatePod returned error: %v", err)
 	}
 
+	deployment := mustGetDeployment(t, service, "clawreef-user-7", "clawreef-43-openclaw-team")
+	if deployment.Spec.Template.Labels["instance-id"] != "43" {
+		t.Fatalf("expected deployment template instance-id label, got %#v", deployment.Spec.Template.Labels)
+	}
+
 	container := pod.Spec.Containers[0]
 	if len(container.EnvFrom) != 1 || container.EnvFrom[0].SecretRef == nil || container.EnvFrom[0].SecretRef.Name != "clawreef-team-1-bus" {
 		t.Fatalf("expected Team secret envFrom, got %#v", container.EnvFrom)
@@ -208,6 +228,48 @@ func TestCreatePodAppliesExtraPVCMountsAndSecretEnv(t *testing.T) {
 	}
 }
 
+func TestSelectCurrentPodPrefersRecoveringDeploymentPod(t *testing.T) {
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "old-evicted"},
+			Status:     corev1.PodStatus{Phase: corev1.PodFailed},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "new-pending"},
+			Status:     corev1.PodStatus{Phase: corev1.PodPending},
+		},
+	}
+
+	selected := selectCurrentPod(pods)
+	if selected == nil || selected.Name != "new-pending" {
+		t.Fatalf("expected recovering pending pod to win over failed pod, got %#v", selected)
+	}
+
+	pods = append(pods, corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "ready"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	})
+
+	selected = selectCurrentPod(pods)
+	if selected == nil || selected.Name != "ready" {
+		t.Fatalf("expected ready running pod to win, got %#v", selected)
+	}
+}
+
 func int64Ptr(value int64) *int64 {
 	return &value
+}
+
+func mustGetDeployment(t *testing.T, service *PodService, namespace, name string) *appsv1.Deployment {
+	t.Helper()
+	deployment, err := service.GetClient().Clientset.AppsV1().Deployments(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected deployment %s/%s to exist: %v", namespace, name, err)
+	}
+	return deployment
 }

--- a/backend/internal/services/k8s/pvc_service.go
+++ b/backend/internal/services/k8s/pvc_service.go
@@ -319,7 +319,7 @@ func (s *PVCService) hostPathPVNodeAffinity(ctx context.Context) (*corev1.Volume
 	}
 	candidates := []candidate{}
 	for _, node := range nodes.Items {
-		if node.Spec.Unschedulable || !isStorageNodeReady(node) {
+		if !isHostPathPVNodeCandidate(node) {
 			continue
 		}
 		hostname := strings.TrimSpace(node.Labels["kubernetes.io/hostname"])
@@ -365,6 +365,18 @@ func isStorageNodeReady(node corev1.Node) bool {
 		}
 	}
 	return false
+}
+
+func isHostPathPVNodeCandidate(node corev1.Node) bool {
+	if node.Spec.Unschedulable || !isStorageNodeReady(node) {
+		return false
+	}
+	for _, taint := range node.Spec.Taints {
+		if taint.Effect == corev1.TaintEffectNoSchedule || taint.Effect == corev1.TaintEffectNoExecute {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *PVCService) monitorPVCBinding(ctx context.Context, namespace, pvcName string, userID, instanceID, storageSizeGB int, storageClass string, timeout time.Duration) {
@@ -467,6 +479,10 @@ func (s *PVCService) createPVForPVC(ctx context.Context, namespace, pvcName stri
 	}
 
 	storageSize := resource.MustParse(fmt.Sprintf("%dGi", storageSizeGB))
+	nodeAffinity, err := s.hostPathPVNodeAffinity(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select node for hostPath PV %s: %w", pvName, err)
+	}
 
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -487,6 +503,7 @@ func (s *PVCService) createPVForPVC(ctx context.Context, namespace, pvcName stri
 			},
 			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
 			StorageClassName:              storageClass,
+			NodeAffinity:                  nodeAffinity,
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: hostPath,

--- a/backend/internal/services/k8s/pvc_service_test.go
+++ b/backend/internal/services/k8s/pvc_service_test.go
@@ -105,6 +105,52 @@ func TestHostPathPVNodeAffinitySkipsUnschedulableAndNotReadyNodes(t *testing.T) 
 	requireHostnameAffinity(t, affinity, "node-c-host")
 }
 
+func TestHostPathPVNodeAffinitySkipsHardTaintedNodes(t *testing.T) {
+	service := &PVCService{
+		client: &Client{
+			Clientset: fake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "k8s-master",
+						Labels: map[string]string{
+							"kubernetes.io/hostname": "k8s-master",
+						},
+					},
+					Spec: corev1.NodeSpec{
+						Taints: []corev1.Taint{
+							{Key: "node-role.kubernetes.io/control-plane", Effect: corev1.TaintEffectNoSchedule},
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "k8s-worker1",
+						Labels: map[string]string{
+							"kubernetes.io/hostname": "k8s-worker1",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			),
+		},
+	}
+
+	affinity, err := service.hostPathPVNodeAffinity(context.Background())
+	if err != nil {
+		t.Fatalf("hostPathPVNodeAffinity returned error: %v", err)
+	}
+	requireHostnameAffinity(t, affinity, "k8s-worker1")
+}
+
 func requireHostnameAffinity(t *testing.T, affinity *corev1.VolumeNodeAffinity, hostname string) {
 	t.Helper()
 	if affinity == nil || affinity.Required == nil || len(affinity.Required.NodeSelectorTerms) != 1 {

--- a/backend/internal/services/skill_service.go
+++ b/backend/internal/services/skill_service.go
@@ -852,15 +852,30 @@ func extractSkillDirectories(filename string, raw []byte) ([]extractedSkillDirec
 		return nil, err
 	}
 
-	grouped := map[string]map[string][]byte{}
+	normalized := map[string][]byte{}
 	for name, content := range fileMap {
-		clean := path.Clean(strings.TrimPrefix(name, "./"))
-		if clean == "." || strings.HasPrefix(clean, "..") {
+		clean := normalizeArchiveEntryPath(name)
+		if clean == "" || isArchiveMetadataEntry(clean) {
 			continue
 		}
+		normalized[clean] = content
+	}
+	if len(normalized) == 0 {
+		return nil, nil
+	}
+
+	if hasSkillManifest(normalized) {
+		return []extractedSkillDirectory{{
+			Name:  archiveSkillName(filename),
+			Files: normalized,
+		}}, nil
+	}
+
+	grouped := map[string]map[string][]byte{}
+	for clean, content := range normalized {
 		parts := strings.Split(clean, "/")
 		if len(parts) < 2 {
-			return nil, fmt.Errorf("archive must contain one or more top-level directories; found loose file %s", clean)
+			return nil, fmt.Errorf("archive must contain SKILL.md at the root or top-level skill directories; found loose file %s", clean)
 		}
 		root := parts[0]
 		if _, ok := grouped[root]; !ok {
@@ -868,8 +883,12 @@ func extractSkillDirectories(filename string, raw []byte) ([]extractedSkillDirec
 		}
 		grouped[root][strings.Join(parts[1:], "/")] = content
 	}
+
 	keys := make([]string, 0, len(grouped))
-	for key := range grouped {
+	for key, files := range grouped {
+		if !hasSkillManifest(files) {
+			return nil, fmt.Errorf("skill directory %s must contain SKILL.md", key)
+		}
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
@@ -878,6 +897,48 @@ func extractSkillDirectories(filename string, raw []byte) ([]extractedSkillDirec
 		result = append(result, extractedSkillDirectory{Name: key, Files: grouped[key]})
 	}
 	return result, nil
+}
+
+func normalizeArchiveEntryPath(value string) string {
+	value = strings.ReplaceAll(value, "\\", "/")
+	value = path.Clean(strings.TrimPrefix(strings.TrimSpace(value), "./"))
+	if value == "." || value == "" || strings.HasPrefix(value, "..") {
+		return ""
+	}
+	return value
+}
+
+func hasSkillManifest(files map[string][]byte) bool {
+	for key := range files {
+		if strings.EqualFold(normalizeArchiveEntryPath(key), "SKILL.md") {
+			return true
+		}
+	}
+	return false
+}
+
+func isArchiveMetadataEntry(value string) bool {
+	clean := normalizeArchiveEntryPath(value)
+	if clean == "" {
+		return true
+	}
+	parts := strings.Split(clean, "/")
+	if parts[0] == "__MACOSX" {
+		return true
+	}
+	base := parts[len(parts)-1]
+	return base == ".DS_Store" || base == "Thumbs.db" || strings.HasPrefix(base, "._")
+}
+
+func archiveSkillName(filename string) string {
+	name := path.Base(strings.ReplaceAll(strings.TrimSpace(filename), "\\", "/"))
+	if ext := path.Ext(name); ext != "" {
+		name = strings.TrimSuffix(name, ext)
+	}
+	if sanitizeSkillKey(name) == "" {
+		return "skill"
+	}
+	return name
 }
 
 func extractArchiveFileMap(filename string, raw []byte) (map[string][]byte, error) {

--- a/backend/internal/services/skill_service_test.go
+++ b/backend/internal/services/skill_service_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"path"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -33,6 +34,7 @@ func TestHashDirectoryPreservesSingleTopLevelSubdirectory(t *testing.T) {
 
 func TestExtractSkillDirectoriesStripsArchiveRootOnlyOnce(t *testing.T) {
 	archive := buildTestZip(t, map[string][]byte{
+		"weather/SKILL.md":    []byte("# Weather\n"),
 		"weather/src/main.py": []byte("print('weather')\n"),
 	})
 
@@ -49,10 +51,91 @@ func TestExtractSkillDirectoriesStripsArchiveRootOnlyOnce(t *testing.T) {
 
 	got := hashDirectory(dirs[0].Files)
 	want := referenceSkillContentMD5(map[string][]byte{
+		"SKILL.md":    []byte("# Weather\n"),
 		"src/main.py": []byte("print('weather')\n"),
 	})
 	if got != want {
 		t.Fatalf("hashDirectory(extracted files) = %s, want %s", got, want)
+	}
+}
+
+func TestExtractSkillDirectoriesAcceptsRootSkillPackage(t *testing.T) {
+	archive := buildTestZip(t, map[string][]byte{
+		".env":                []byte("TOKEN=example\n"),
+		"SKILL.md":            []byte("# Weather\n"),
+		"__MACOSX/._SKILL.md": []byte("metadata\n"),
+		"scripts/run.sh":      []byte("python src/main.py\n"),
+		"src/main.py":         []byte("print('weather')\n"),
+	})
+
+	dirs, err := extractSkillDirectories("weather.zip", archive)
+	if err != nil {
+		t.Fatalf("extractSkillDirectories() error = %v", err)
+	}
+	if len(dirs) != 1 {
+		t.Fatalf("extractSkillDirectories() returned %d dirs, want 1", len(dirs))
+	}
+	if dirs[0].Name != "weather" {
+		t.Fatalf("root skill package name = %q, want weather", dirs[0].Name)
+	}
+	if _, ok := dirs[0].Files["SKILL.md"]; !ok {
+		t.Fatalf("expected root SKILL.md to be preserved: %#v", dirs[0].Files)
+	}
+	if _, ok := dirs[0].Files["scripts/run.sh"]; !ok {
+		t.Fatalf("expected root scripts/run.sh to be preserved: %#v", dirs[0].Files)
+	}
+	if _, ok := dirs[0].Files[".env"]; !ok {
+		t.Fatalf("expected root .env to be preserved for scanning: %#v", dirs[0].Files)
+	}
+	if _, ok := dirs[0].Files["__MACOSX/._SKILL.md"]; ok {
+		t.Fatalf("expected archive metadata to be ignored: %#v", dirs[0].Files)
+	}
+}
+
+func TestExtractSkillDirectoriesImportsMultipleManifestDirs(t *testing.T) {
+	archive := buildTestZip(t, map[string][]byte{
+		"alpha/SKILL.md": []byte("# Alpha\n"),
+		"beta/SKILL.md":  []byte("# Beta\n"),
+	})
+
+	dirs, err := extractSkillDirectories("skills.zip", archive)
+	if err != nil {
+		t.Fatalf("extractSkillDirectories() error = %v", err)
+	}
+	if len(dirs) != 2 {
+		t.Fatalf("extractSkillDirectories() returned %d dirs, want 2", len(dirs))
+	}
+	if dirs[0].Name != "alpha" || dirs[1].Name != "beta" {
+		t.Fatalf("skill directory names = %q, %q; want alpha, beta", dirs[0].Name, dirs[1].Name)
+	}
+}
+
+func TestExtractSkillDirectoriesRejectsTopLevelDirWithoutManifest(t *testing.T) {
+	archive := buildTestZip(t, map[string][]byte{
+		"weather/src/main.py": []byte("print('weather')\n"),
+	})
+
+	_, err := extractSkillDirectories("weather.zip", archive)
+	if err == nil {
+		t.Fatal("extractSkillDirectories() error = nil, want SKILL.md error")
+	}
+	if !strings.Contains(err.Error(), "SKILL.md") {
+		t.Fatalf("extractSkillDirectories() error = %v, want SKILL.md error", err)
+	}
+}
+
+func TestExtractSkillDirectoriesRejectsLooseFileWithoutRootManifest(t *testing.T) {
+	archive := buildTestZip(t, map[string][]byte{
+		"README.md":        []byte("not a skill manifest\n"),
+		"weather/SKILL.md": []byte("# Weather\n"),
+	})
+
+	_, err := extractSkillDirectories("weather.zip", archive)
+	if err == nil {
+		t.Fatal("extractSkillDirectories() error = nil, want loose file error")
+	}
+	if !strings.Contains(err.Error(), "loose file README.md") {
+		t.Fatalf("extractSkillDirectories() error = %v, want loose README.md error", err)
 	}
 }
 

--- a/backend/internal/services/sync_service.go
+++ b/backend/internal/services/sync_service.go
@@ -99,6 +99,31 @@ func (s *SyncService) syncInstance(ctx context.Context, instance *models.Instanc
 	// Check if pod exists in K8s
 	pod, err := s.podService.GetPod(ctx, instance.UserID, instance.ID)
 	if err != nil {
+		deploymentExists, deploymentErr := s.podService.DeploymentExists(ctx, instance.UserID, instance.ID)
+		if deploymentErr != nil {
+			fmt.Printf("Instance %d: failed to check deployment while pod was missing: %v\n", instance.ID, deploymentErr)
+		}
+		if deploymentExists {
+			if instance.Status != "creating" {
+				fmt.Printf("Instance %d has deployment but no pod yet, updating status to creating\n", instance.ID)
+				instance.Status = "creating"
+				instance.PodName = nil
+				instance.PodNamespace = nil
+				instance.PodIP = nil
+				instance.UpdatedAt = time.Now()
+
+				if err := s.instanceRepo.Update(instance); err != nil {
+					fmt.Printf("Error updating instance %d status: %v\n", instance.ID, err)
+				} else {
+					s.updateInfraStatus(instance.ID, "creating")
+					GetHub().BroadcastInstanceStatus(instance.UserID, instance)
+				}
+			} else {
+				s.updateInfraStatus(instance.ID, "creating")
+			}
+			return
+		}
+
 		// Pod doesn't exist in K8s
 		if instance.Status == "running" || instance.Status == "creating" {
 			nextStatus := "stopped"

--- a/deployments/k3s/clawmanager.yaml
+++ b/deployments/k3s/clawmanager.yaml
@@ -664,6 +664,13 @@ data:
       UNIQUE KEY uk_openclaw_bundle_skill (bundle_id, skill_id),
       INDEX idx_openclaw_bundle_skill_bundle (bundle_id, sort_order)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  023_normalize_runtime_config_mounts.sql: |
+    USE clawmanager;
+    UPDATE instances
+    SET mount_path = '/config',
+        updated_at = CURRENT_TIMESTAMP
+    WHERE type IN ('openclaw', 'ubuntu', 'webtop', 'hermes')
+      AND mount_path IN ('/data', '/home/user/data', '/config/.hermes');
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/deployments/k8s/clawmanager.yaml
+++ b/deployments/k8s/clawmanager.yaml
@@ -668,6 +668,13 @@ data:
       UNIQUE KEY uk_openclaw_bundle_skill (bundle_id, skill_id),
       INDEX idx_openclaw_bundle_skill_bundle (bundle_id, sort_order)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  023_normalize_runtime_config_mounts.sql: |
+    USE clawmanager;
+    UPDATE instances
+    SET mount_path = '/config',
+        updated_at = CURRENT_TIMESTAMP
+    WHERE type IN ('openclaw', 'ubuntu', 'webtop', 'hermes')
+      AND mount_path IN ('/data', '/home/user/data', '/config/.hermes');
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/docs/hermes-runtime-agent-development.md
+++ b/docs/hermes-runtime-agent-development.md
@@ -12,11 +12,12 @@ A Hermes image must satisfy two layers of requirements:
 Current Hermes runtime defaults in ClawManager:
 
 - Port: `3001`
+- PVC mount path: `/config`
 - Persistent directory: `/config/.hermes`
 - Default title: `Hermes Runtime`
 - Proxy path: ClawManager rewrites `SUBFOLDER` to `/api/v1/instances/{instance_id}/proxy/` when the instance is created.
 
-Do not change the port or persistent directory in the image. If the image uses a different port or mount path, instance proxying, PVC mounting, and user data persistence will no longer match ClawManager expectations.
+Do not change the port, PVC mount path, or persistent directory in the image. ClawManager mounts the instance PVC at `/config` so Webtop desktop files such as `/config/Desktop` and Hermes runtime files under `/config/.hermes` persist together.
 
 ## Image Build Requirements
 
@@ -799,7 +800,7 @@ Never commit real tokens, channel secrets, Gateway API keys, or downloaded sessi
 Before delivering a Hermes image, verify:
 
 - The Webtop desktop is reachable through the ClawManager instance proxy.
-- `/config/.hermes` is mounted and persists across restarts.
+- `/config` is mounted and both `/config/Desktop` and `/config/.hermes` persist across restarts.
 - The agent registers and starts heartbeat within 30 seconds.
 - The instance detail page shows agent online, runtime running, and an updated last report time.
 - CPU, memory, disk, and network metrics are visible and refresh continuously.
@@ -819,7 +820,7 @@ ClawManager must keep the following capabilities for Hermes to work end to end:
 - Allow `hermes` instances to register with the Agent Control Plane.
 - Inject `CLAWMANAGER_LLM_*` and OpenAI-compatible variables so Hermes can access models through ClawManager AI Gateway.
 - Inject Hermes and generic runtime bootstrap variables for channels, skills, and related resources.
-- Mount persistent storage at `/config/.hermes`.
+- Mount persistent storage at `/config`, while keeping Hermes runtime state under `/config/.hermes`.
 - Support `.hermes` import and export.
 - Keep compatibility fields such as `openclaw_status`, `openclaw_pid`, and `openclaw_version` until generic runtime fields are introduced.
 - Add Hermes-specific runtime control commands, or generic `start_runtime`, `stop_runtime`, and `restart_runtime`, if runtime process control becomes required.

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -2027,7 +2027,7 @@ export const translations: Record<Locale, TranslationTree> = {
       paginationPrev: "Previous",
       paginationNext: "Next",
       skillUploadHint:
-        "Upload `.zip` only. Each top-level directory is imported as one skill.",
+        "Upload `.zip` only. Put SKILL.md at the archive root for one skill, or in each top-level directory for batch import.",
       loadingSkills: "Loading skills...",
       noSkills: "No skills uploaded yet.",
       skillMeta: "{key} · risk {risk} · used by {count} instance(s)",
@@ -3229,7 +3229,8 @@ export const translations: Record<Locale, TranslationTree> = {
       paginationSummary: "每页 {pageSize} 条，本页显示 {from}-{to}",
       paginationPrev: "上一页",
       paginationNext: "下一页",
-      skillUploadHint: "仅支持上传 `.zip`。每个一级目录会被导入为一个技能。",
+      skillUploadHint:
+        "仅支持上传 `.zip`。单个技能可把 SKILL.md 放在压缩包根目录；批量导入时每个一级目录都需要包含 SKILL.md。",
       loadingSkills: "正在加载技能...",
       noSkills: "暂时还没有上传任何技能。",
       skillMeta: "{key} · 风险 {risk} · 已被 {count} 个实例使用",
@@ -4493,7 +4494,7 @@ export const translations: Record<Locale, TranslationTree> = {
       paginationPrev: "前へ",
       paginationNext: "次へ",
       skillUploadHint:
-        "`.zip` のみアップロードできます。トップレベルの各ディレクトリが 1 つのスキルとして取り込まれます。",
+        "`.zip` のみアップロードできます。単一スキルはルートに SKILL.md、複数スキルは各トップレベルディレクトリに SKILL.md を置いてください。",
       loadingSkills: "スキルを読み込み中...",
       noSkills: "まだアップロードされたスキルはありません。",
       skillMeta: "{key} · リスク {risk} · {count} インスタンスで使用中",
@@ -5748,7 +5749,7 @@ export const translations: Record<Locale, TranslationTree> = {
       paginationPrev: "이전 페이지",
       paginationNext: "다음 페이지",
       skillUploadHint:
-        "`.zip`만 업로드할 수 있습니다. 최상위 디렉터리 하나가 스킬 하나로 가져와집니다.",
+        "`.zip`만 업로드할 수 있습니다. 단일 스킬은 루트에 SKILL.md를 두고, 일괄 가져오기는 각 최상위 디렉터리에 SKILL.md를 두세요.",
       loadingSkills: "스킬을 불러오는 중...",
       noSkills: "업로드된 스킬이 아직 없습니다.",
       skillMeta: "{key} · 위험도 {risk} · {count}개 인스턴스에서 사용 중",
@@ -7034,7 +7035,7 @@ export const translations: Record<Locale, TranslationTree> = {
       paginationPrev: "Zurück",
       paginationNext: "Weiter",
       skillUploadHint:
-        "Nur `.zip` hochladen. Jedes Verzeichnis auf oberster Ebene wird als ein Skill importiert.",
+        "Nur `.zip` hochladen. Für einen Skill SKILL.md im Archivstamm ablegen; für Batch-Importe SKILL.md in jedem Verzeichnis oberster Ebene ablegen.",
       loadingSkills: "Skills werden geladen...",
       noSkills: "Noch keine Skills hochgeladen.",
       skillMeta: "{key} · Risiko {risk} · in {count} Instanz(en) verwendet",

--- a/frontend/src/pages/teams/CreateTeamPage.tsx
+++ b/frontend/src/pages/teams/CreateTeamPage.tsx
@@ -91,7 +91,7 @@ const BUILTIN_MEMBER_TEMPLATES: TeamMemberTemplate[] = [
         image: "",
       },
       {
-        memberId: "worker",
+        memberId: "worker-1",
         name: "team-worker",
         role: "developer",
         runtimeType: "openclaw",
@@ -308,7 +308,7 @@ const defaultMember = (
   overrides?: Partial<TeamMemberDraft>,
 ): TeamMemberDraft => ({
   id: newDraftId(),
-  memberId: "worker",
+  memberId: "worker-1",
   name: "",
   role: "developer",
   runtimeType: "openclaw",
@@ -398,6 +398,34 @@ const uniqueMemberId = (raw: string, usedIds: Set<string>, fallbackIndex: number
   return candidate;
 };
 
+const nextWorkerMemberId = (members: TeamMemberDraft[]) => {
+  const usedIds = new Set(
+    members
+      .map((member) => normalizeMemberId(member.memberId))
+      .filter(Boolean),
+  );
+  let maxWorkerIndex = 0;
+
+  usedIds.forEach((memberId) => {
+    if (memberId === "worker") {
+      maxWorkerIndex = Math.max(maxWorkerIndex, 1);
+      return;
+    }
+    const match = memberId.match(/^worker-(\d+)$/);
+    if (match) {
+      maxWorkerIndex = Math.max(maxWorkerIndex, Number(match[1]));
+    }
+  });
+
+  let candidateIndex = maxWorkerIndex + 1;
+  let candidate = `worker-${candidateIndex}`;
+  while (usedIds.has(candidate)) {
+    candidateIndex += 1;
+    candidate = `worker-${candidateIndex}`;
+  }
+  return candidate;
+};
+
 const CreateTeamPage: React.FC = () => {
   const navigate = useNavigate();
   const [name, setName] = useState("");
@@ -421,7 +449,7 @@ const CreateTeamPage: React.FC = () => {
       isLeader: true,
     }),
     defaultMember({
-      memberId: "worker",
+      memberId: "worker-1",
       role: "developer",
     }),
   ]);
@@ -576,11 +604,10 @@ const CreateTeamPage: React.FC = () => {
   };
 
   const addMember = () => {
-    const nextIndex = members.length + 1;
     setMembers((current) => [
       ...current,
       defaultMember({
-        memberId: `worker-${nextIndex}`,
+        memberId: nextWorkerMemberId(current),
         image: selectedImage?.image || "",
       }),
     ]);


### PR DESCRIPTION
- Create instance workloads as single-replica Deployments instead of bare Pods so Kubernetes can recreate Pods after deletion, eviction, or node/runtime failures.
- Update stop/delete and orphan cleanup to remove Deployments before residual Pods, and improve status sync to keep instances creating while a Deployment exists without a Pod and avoid stale Failed/Evicted Pods affecting instance state.
- Fix resource skill upload and team member numbering.
- Mount Hermes/desktop PVCs at /config with legacy layout migration.