### PR TITLE
fix(docs): restore working Star History charts

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -323,10 +323,10 @@ Issues und Pull Requests sind willkommen.
 
 ## Star History
 
-<a href="https://github.com/Yuan-lab-LLM/ClawManager/actions/workflows/update-star-history.yml">
+<a href="https://star-history.dera.page/#Yuan-lab-LLM/ClawManager&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-dark.svg" />
-   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
-   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
  </picture>
 </a>

--- a/README.ja.md
+++ b/README.ja.md
@@ -323,10 +323,10 @@ Issue と Pull Request を歓迎します。
 
 ## Star History
 
-<a href="https://github.com/Yuan-lab-LLM/ClawManager/actions/workflows/update-star-history.yml">
+<a href="https://star-history.dera.page/#Yuan-lab-LLM/ClawManager&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-dark.svg" />
-   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
-   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
  </picture>
 </a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -323,10 +323,10 @@ Issue와 Pull Request를 환영합니다.
 
 ## Star History
 
-<a href="https://github.com/Yuan-lab-LLM/ClawManager/actions/workflows/update-star-history.yml">
+<a href="https://star-history.dera.page/#Yuan-lab-LLM/ClawManager&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-dark.svg" />
-   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
-   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
  </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -321,10 +321,10 @@ Issues and pull requests are welcome.
 
 ## Star History
 
-<a href="https://github.com/Yuan-lab-LLM/ClawManager/actions/workflows/update-star-history.yml">
+<a href="https://star-history.dera.page/#Yuan-lab-LLM/ClawManager&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-dark.svg" />
-   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
-   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
  </picture>
 </a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -326,10 +326,10 @@ ClawManager 是一个 Kubernetes 原生平台，包含 React 前端、Go 后端�
 
 ## Star History
 
-<a href="https://github.com/Yuan-lab-LLM/ClawManager/actions/workflows/update-star-history.yml">
+<a href="https://star-history.dera.page/#Yuan-lab-LLM/ClawManager&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-dark.svg" />
-   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
-   <img alt="Star History Chart" src="https://raw.githubusercontent.com/Yuan-lab-LLM/ClawManager/star-history/star-history-light.svg" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Yuan-lab-LLM/ClawManager&type=date&theme=light" />
  </picture>
 </a>


### PR DESCRIPTION
The current Star History charts are broken, leaving the project documentation without a usable star history. Restore the charts in the main and localized READMEs so readers can view the repository's star history again.