### PR TITLE
feat(opencode): use per-instance dedicated origins

### DIFF
--- a/backend/internal/db/runtime_manifest_test.go
+++ b/backend/internal/db/runtime_manifest_test.go
@@ -63,6 +63,42 @@ func TestRuntimeManifestsExposeDeepSeekHarnessPublicURLTemplate(t *testing.T) {
 	}
 }
 
+func TestRuntimeManifestsExposeOpenCodePublicURLTemplate(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	for _, manifest := range deploymentRuntimeManifests(repoRoot) {
+		t.Run(manifest, func(t *testing.T) {
+			raw, err := os.ReadFile(manifest)
+			if err != nil {
+				t.Fatalf("read manifest: %v", err)
+			}
+			if !strings.Contains(string(raw), "name: CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE") {
+				t.Fatalf("manifest %s must expose the OpenCode public URL template", manifest)
+			}
+		})
+	}
+}
+
+func TestNginxRoutesOpenCodePerInstanceOrigins(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	raw, err := os.ReadFile(filepath.Join(repoRoot, "deployments", "nginx", "nginx.conf"))
+	if err != nil {
+		t.Fatalf("read nginx config: %v", err)
+	}
+	text := string(raw)
+	for _, required := range []string{
+		"server_name ~^opencode-(?<runtime_inst_id>[0-9]+)\\..+$;",
+		"X-ClawManager-Runtime-Origin opencode",
+		"/api/v1/instances/$runtime_inst_id/proxy$1",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("nginx config must contain %q", required)
+		}
+	}
+	if got := strings.Count(text, "proxy_set_header X-ClawManager-Runtime-Origin \"\";"); got < 2 {
+		t.Fatalf("public nginx routes must clear the dedicated-origin marker, got %d guards", got)
+	}
+}
+
 func TestDesktopAuthAcceptsDedicatedRuntimeInstanceVariable(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	raw, err := os.ReadFile(filepath.Join(repoRoot, "deployments", "nginx", "njs", "desktop_auth.js"))

--- a/backend/internal/handlers/instance_handler.go
+++ b/backend/internal/handlers/instance_handler.go
@@ -1647,7 +1647,15 @@ func (h *InstanceHandler) proxyAccessToken(c *gin.Context, id int) (string, bool
 	queryToken := strings.TrimSpace(c.Query("token"))
 	if queryToken != "" {
 		if accessToken, validateErr := h.accessService.ValidateToken(queryToken); validateErr == nil && accessToken.InstanceID == id {
-			h.promoteProxyAccessTokenCookie(c, id, cookieName, queryToken, accessToken)
+			dedicatedOrigin := h.promoteProxyAccessTokenCookie(c, id, cookieName, queryToken, accessToken)
+			originRuntimeType, _ := services.NormalizeV2RuntimeType(c.GetHeader(services.DedicatedRuntimeOriginHeader))
+			if dedicatedOrigin && originRuntimeType == services.RuntimeTypeOpenCode &&
+				(c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) {
+				// Promote the one-time query token to the dedicated origin's cookie and
+				// immediately remove it from the visible browser URL.
+				c.Redirect(http.StatusTemporaryRedirect, dedicatedRuntimeCleanLocation(c.Request.URL, id, queryToken))
+				return "", false
+			}
 			return queryToken, true
 		}
 	}
@@ -1666,7 +1674,7 @@ func (h *InstanceHandler) proxyAccessToken(c *gin.Context, id int) (string, bool
 	return "", false
 }
 
-func (h *InstanceHandler) promoteProxyAccessTokenCookie(c *gin.Context, id int, cookieName, queryToken string, accessToken *services.AccessToken) {
+func (h *InstanceHandler) promoteProxyAccessTokenCookie(c *gin.Context, id int, cookieName, queryToken string, accessToken *services.AccessToken) bool {
 	// Promote only a validated ClawManager access token. Runtime applications may
 	// also use a token query parameter for their own websocket/session protocol.
 	cookiePath := fmt.Sprintf("/api/v1/instances/%d/proxy", id)
@@ -1674,7 +1682,7 @@ func (h *InstanceHandler) promoteProxyAccessTokenCookie(c *gin.Context, id int, 
 	originRuntimeType, originManaged := services.NormalizeV2RuntimeType(c.GetHeader(services.DedicatedRuntimeOriginHeader))
 	instanceRuntimeType, instanceManaged := services.NormalizeV2RuntimeType(accessToken.InstanceType)
 	dedicatedOrigin := originManaged && instanceManaged && originRuntimeType == instanceRuntimeType &&
-		originRuntimeType == services.RuntimeTypeDeepSeekHarness
+		(originRuntimeType == services.RuntimeTypeOpenCode || originRuntimeType == services.RuntimeTypeDeepSeekHarness)
 	if dedicatedOrigin {
 		cookiePath = "/"
 		cookieSecure = true
@@ -1689,6 +1697,40 @@ func (h *InstanceHandler) promoteProxyAccessTokenCookie(c *gin.Context, id int, 
 		cookieSecure,
 		true,
 	)
+	return dedicatedOrigin
+}
+
+func dedicatedRuntimeCleanLocation(requestURL *url.URL, instanceID int, accessToken string) string {
+	if requestURL == nil {
+		return "/"
+	}
+	prefix := fmt.Sprintf("/api/v1/instances/%d/proxy", instanceID)
+	pathValue := strings.TrimPrefix(requestURL.Path, prefix)
+	if pathValue == "" {
+		pathValue = "/"
+	} else if !strings.HasPrefix(pathValue, "/") {
+		pathValue = "/" + pathValue
+	}
+
+	query := requestURL.Query()
+	values := query["token"]
+	if len(values) > 0 {
+		kept := values[:0]
+		for _, value := range values {
+			if value != accessToken {
+				kept = append(kept, value)
+			}
+		}
+		if len(kept) == 0 {
+			query.Del("token")
+		} else {
+			query["token"] = kept
+		}
+	}
+	if encoded := query.Encode(); encoded != "" {
+		return pathValue + "?" + encoded
+	}
+	return pathValue
 }
 
 func (h *InstanceHandler) proxyInstanceWithToken(c *gin.Context, id int, token string) {
@@ -1697,6 +1739,8 @@ func (h *InstanceHandler) proxyInstanceWithToken(c *gin.Context, id int, token s
 		if err := h.proxyService.ProxyWebSocket(c.Request.Context(), id, token, c.Writer, c.Request); err != nil {
 			if errors.Is(err, services.ErrInstanceGatewayUnavailable) {
 				http.Error(c.Writer, "Instance gateway is not available", http.StatusServiceUnavailable)
+			} else if errors.Is(err, services.ErrOpenCodeDedicatedOriginRequired) {
+				http.Error(c.Writer, err.Error(), http.StatusNotFound)
 			} else {
 				http.Error(c.Writer, err.Error(), http.StatusBadGateway)
 			}
@@ -1717,6 +1761,8 @@ func (h *InstanceHandler) proxyInstanceWithToken(c *gin.Context, id int, token s
 			http.Error(c.Writer, "Token does not match instance", http.StatusForbidden)
 		} else if errors.Is(err, services.ErrInstanceGatewayUnavailable) {
 			http.Error(c.Writer, "Instance gateway is not available", http.StatusServiceUnavailable)
+		} else if errors.Is(err, services.ErrOpenCodeDedicatedOriginRequired) {
+			http.Error(c.Writer, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(c.Writer, fmt.Sprintf("Failed to proxy request: %v", err), http.StatusBadGateway)
 		}

--- a/backend/internal/handlers/instance_handler_test.go
+++ b/backend/internal/handlers/instance_handler_test.go
@@ -839,6 +839,67 @@ func TestProxyAccessTokenRejectsRuntimeQueryTokenWithoutCookie(t *testing.T) {
 	}
 }
 
+func TestProxyAccessTokenBootstrapsDedicatedOpenCodeOriginCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	accessService := services.NewInstanceAccessService()
+	defer accessService.Stop()
+	token, err := accessService.GenerateToken(
+		1,
+		171,
+		services.RuntimeTypeOpenCode,
+		"https://opencode-171.runtime.example.test/",
+		"",
+		20000,
+		time.Hour,
+	)
+	if err != nil {
+		t.Fatalf("GenerateToken returned error: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	requestURL := "/api/v1/instances/171/proxy/?token=" + url.QueryEscape(token.Token) + "&token=runtime-session&view=compact"
+	c.Request = httptest.NewRequest(http.MethodGet, requestURL, nil)
+	c.Request.Header.Set(services.DedicatedRuntimeOriginHeader, services.RuntimeTypeOpenCode)
+
+	handler := &InstanceHandler{accessService: accessService}
+	if got, ok := handler.proxyAccessToken(c, 171); ok || got != "" {
+		t.Fatalf("proxyAccessToken = %q/%v, want redirect after cookie bootstrap", got, ok)
+	}
+	if recorder.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusTemporaryRedirect)
+	}
+	if got := recorder.Header().Get("Location"); got != "/?token=runtime-session&view=compact" {
+		t.Fatalf("Location = %q", got)
+	}
+	setCookie := recorder.Header().Get("Set-Cookie")
+	for _, want := range []string{
+		"instance_access_171=",
+		"Path=/",
+		"HttpOnly",
+		"Secure",
+		"SameSite=None",
+	} {
+		if !strings.Contains(setCookie, want) {
+			t.Fatalf("Set-Cookie missing %q: %s", want, setCookie)
+		}
+	}
+	if strings.Contains(recorder.Header().Get("Location"), token.Token) {
+		t.Fatal("redirect leaked the ClawManager access token")
+	}
+}
+
+func TestDedicatedRuntimeCleanLocationUsesRootPath(t *testing.T) {
+	requestURL, err := url.Parse("/api/v1/instances/171/proxy/assets/app.js?token=access&lang=zh-CN")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := dedicatedRuntimeCleanLocation(requestURL, 171, "access")
+	if want := "/assets/app.js?lang=zh-CN"; got != want {
+		t.Fatalf("dedicatedRuntimeCleanLocation() = %q, want %q", got, want)
+	}
+}
+
 func TestBrowserAccessEntryURLBootstrapsDedicatedOrigin(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/backend/internal/services/instance_proxy_service.go
+++ b/backend/internal/services/instance_proxy_service.go
@@ -62,13 +62,17 @@ type serviceLookupCall struct {
 
 const (
 	defaultServiceCacheTTL                 = 30 * time.Second
+	openCodePublicURLTemplateEnvVar        = "CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE"
 	deepSeekHarnessPublicURLTemplateEnvVar = "CLAWMANAGER_DEEPSEEK_HARNESS_PUBLIC_URL_TEMPLATE"
 )
 
 // DedicatedRuntimeOriginHeader marks requests routed through a runtime-specific browser origin.
 const DedicatedRuntimeOriginHeader = "X-ClawManager-Runtime-Origin"
 
-var ErrInstanceGatewayUnavailable = errors.New("instance gateway is not available")
+var (
+	ErrInstanceGatewayUnavailable      = errors.New("instance gateway is not available")
+	ErrOpenCodeDedicatedOriginRequired = errors.New("OpenCode Lite requires its dedicated instance origin")
+)
 
 type InstanceProxyServiceOption func(*InstanceProxyService)
 
@@ -142,6 +146,10 @@ func (s *InstanceProxyService) ProxyRequest(ctx context.Context, instanceID int,
 
 	effectiveRequestPath := canonicalProxyEntryRequestPath(r.URL.Path, accessToken, instanceID)
 	dedicatedRuntimeOrigin := isDedicatedRuntimeOriginRequest(r, accessToken.InstanceType)
+	opencodeLite := s.isOpenCodeLiteProxyInstance(instanceID, accessToken.InstanceType)
+	if opencodeLite && !dedicatedRuntimeOrigin {
+		return ErrOpenCodeDedicatedOriginRequired
+	}
 
 	// Extract the actual path from the request (remove the proxy prefix)
 	targetPath := s.extractTargetPath(effectiveRequestPath, instanceID, accessToken.InstanceType)
@@ -157,7 +165,6 @@ func (s *InstanceProxyService) ProxyRequest(ctx context.Context, instanceID int,
 	managedGatewayToken := s.managedRuntimeGatewayBearerToken(ctx, instanceID, accessToken.InstanceType)
 	proxyPrefix := hermesProxyPrefix(instanceID)
 	hermesLite := s.isHermesLiteProxyInstance(instanceID, accessToken.InstanceType)
-	opencodeLite := s.isOpenCodeLiteProxyInstance(instanceID, accessToken.InstanceType)
 	bootstrapPath := stripInstanceProxyPrefix(targetPath, instanceID)
 
 	// Copy query parameters, excluding ClawManager-owned proxy/gateway tokens.
@@ -239,7 +246,11 @@ func (s *InstanceProxyService) ProxyRequest(ctx context.Context, instanceID int,
 	proxyReq.Header.Set("X-Forwarded-For", r.RemoteAddr)
 	proxyReq.Header.Set("X-Forwarded-Host", r.Host)
 	proxyReq.Header.Set("X-Forwarded-Proto", requestScheme(r))
-	proxyReq.Header.Set("X-Forwarded-Prefix", proxyPrefix)
+	if dedicatedRuntimeOrigin {
+		proxyReq.Header.Del("X-Forwarded-Prefix")
+	} else {
+		proxyReq.Header.Set("X-Forwarded-Prefix", proxyPrefix)
+	}
 	if opencodeLite {
 		setOpenCodeServerBasicAuthHeaders(proxyReq.Header, managedGatewayToken)
 	} else if !isHermesDashboardPublicAuthPath(bootstrapPath) {
@@ -268,6 +279,11 @@ func (s *InstanceProxyService) ProxyRequest(ctx context.Context, instanceID int,
 
 	if location := resp.Header.Get("Location"); location != "" && !dedicatedRuntimeOrigin {
 		resp.Header.Set("Location", s.rewriteRedirectLocation(instanceID, location))
+	}
+	// OpenCode is authenticated on the internal hop. Never expose its Basic
+	// challenge to the browser, where it would open a native login dialog.
+	if opencodeLite {
+		resp.Header.Del("WWW-Authenticate")
 	}
 
 	if openCodeProjectSearchRewritten && resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
@@ -395,6 +411,10 @@ func (s *InstanceProxyService) ProxyWebSocket(ctx context.Context, instanceID in
 		return fmt.Errorf("token does not match instance")
 	}
 	dedicatedRuntimeOrigin := isDedicatedRuntimeOriginRequest(r, accessToken.InstanceType)
+	opencodeLite := s.isOpenCodeLiteProxyInstance(instanceID, accessToken.InstanceType)
+	if opencodeLite && !dedicatedRuntimeOrigin {
+		return ErrOpenCodeDedicatedOriginRequired
+	}
 
 	// Extract the actual path from the request
 	targetPath := s.extractTargetPath(r.URL.Path, instanceID, accessToken.InstanceType)
@@ -408,7 +428,6 @@ func (s *InstanceProxyService) ProxyWebSocket(ctx context.Context, instanceID in
 	managedGatewayToken := s.managedRuntimeGatewayBearerToken(ctx, instanceID, accessToken.InstanceType)
 	upstreamPath := stripInstanceProxyPrefix(targetPath, instanceID)
 	hermesLite := s.isHermesLiteProxyInstance(instanceID, accessToken.InstanceType)
-	opencodeLite := s.isOpenCodeLiteProxyInstance(instanceID, accessToken.InstanceType)
 	skipManagedWSAuth := hermesLite && isHermesDashboardTicketWebSocket(upstreamPath, r.URL.Query())
 
 	// Copy query parameters, excluding ClawManager-owned proxy/gateway tokens.
@@ -438,7 +457,11 @@ func (s *InstanceProxyService) ProxyWebSocket(ctx context.Context, instanceID in
 	upstreamHeader.Set("X-Forwarded-For", r.RemoteAddr)
 	upstreamHeader.Set("X-Forwarded-Host", r.Host)
 	upstreamHeader.Set("X-Forwarded-Proto", requestScheme(r))
-	upstreamHeader.Set("X-Forwarded-Prefix", fmt.Sprintf("/api/v1/instances/%d/proxy", instanceID))
+	if dedicatedRuntimeOrigin {
+		upstreamHeader.Del("X-Forwarded-Prefix")
+	} else {
+		upstreamHeader.Set("X-Forwarded-Prefix", fmt.Sprintf("/api/v1/instances/%d/proxy", instanceID))
+	}
 	// Hermes dashboard chat uses cookie + ticket query auth. Do not inject
 	// managed Bearer/API-Key headers or rewrite Origin for those sockets.
 	if skipManagedWSAuth {
@@ -594,7 +617,7 @@ func isDedicatedRuntimeOriginRequest(r *http.Request, instanceType string) bool 
 	if !managed || !originManaged || runtimeType != originRuntimeType {
 		return false
 	}
-	return runtimeType == RuntimeTypeDeepSeekHarness
+	return runtimeType == RuntimeTypeOpenCode || runtimeType == RuntimeTypeDeepSeekHarness
 }
 
 func setOpenCodeServerBasicAuthHeaders(header http.Header, token string) {
@@ -1331,6 +1354,12 @@ func (s *InstanceProxyService) GetProxyURLForInstance(instance *models.Instance,
 	if instance == nil {
 		return ""
 	}
+	if runtimeType, ok := v2RuntimeTypeForInstance(instance); ok && runtimeType == RuntimeTypeOpenCode {
+		// OpenCode's web UI owns the root of its origin. Do not fall back to the
+		// legacy /instances/{id}/proxy subpath when the deployment forgot its
+		// dedicated-origin template; fail access generation instead.
+		return managedRuntimePublicURL(runtimeType, instance.ID, token)
+	}
 	if runtimeType, ok := v2RuntimeTypeForInstance(instance); ok && runtimeType == RuntimeTypeDeepSeekHarness {
 		if publicURL := managedRuntimePublicURL(runtimeType, instance.ID, token); publicURL != "" {
 			return publicURL
@@ -1348,6 +1377,8 @@ func managedRuntimePublicURL(runtimeType string, instanceID int, token string) s
 	// wildcard DNS (for example nip.io) and an offline authoritative DNS zone.
 	var envVar string
 	switch runtimeType {
+	case RuntimeTypeOpenCode:
+		envVar = openCodePublicURLTemplateEnvVar
 	case RuntimeTypeDeepSeekHarness:
 		envVar = deepSeekHarnessPublicURLTemplateEnvVar
 	default:

--- a/backend/internal/services/instance_proxy_service_v2_test.go
+++ b/backend/internal/services/instance_proxy_service_v2_test.go
@@ -148,6 +148,72 @@ func TestInstanceProxyServicePreservesDeepSeekHarnessPluginBatchRawQuery(t *test
 	}
 }
 
+func TestInstanceProxyServiceKeepsOpenCodeDedicatedOriginAtRoot(t *testing.T) {
+	instanceToken := "igt_opencode_instance"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "opencode" || password != instanceToken {
+			t.Fatalf("BasicAuth = %q/%q/%v", username, password, ok)
+		}
+		if got := r.Header.Get("X-Forwarded-Prefix"); got != "" {
+			t.Fatalf("X-Forwarded-Prefix = %q, want empty for dedicated origin", got)
+		}
+		if r.URL.Path == "/redirect" {
+			w.Header().Set("Location", "/session/next")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<!doctype html><html><head><script src="/assets/app.js"></script></head><body></body></html>`))
+	}))
+	defer upstream.Close()
+
+	service, token := newOpenCodeV2ProxyTestService(t, upstream.URL, 134, instanceToken)
+	client := upstream.Client()
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	service.httpClient = client
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/instances/134/proxy/?token="+url.QueryEscape(token.Token), nil)
+	req.Header.Set(DedicatedRuntimeOriginHeader, RuntimeTypeOpenCode)
+	rec := httptest.NewRecorder()
+	if err := service.ProxyRequest(req.Context(), 134, token.Token, rec, req); err != nil {
+		t.Fatalf("ProxyRequest returned error: %v", err)
+	}
+	if strings.Contains(rec.Body.String(), "<base ") || strings.Contains(rec.Body.String(), "/api/v1/instances/134/proxy") {
+		t.Fatalf("dedicated-origin HTML was rewritten as a subpath: %s", rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/instances/134/proxy/redirect?token="+url.QueryEscape(token.Token), nil)
+	req.Header.Set(DedicatedRuntimeOriginHeader, RuntimeTypeOpenCode)
+	rec = httptest.NewRecorder()
+	if err := service.ProxyRequest(req.Context(), 134, token.Token, rec, req); err != nil {
+		t.Fatalf("redirect ProxyRequest returned error: %v", err)
+	}
+	if got := rec.Header().Get("Location"); got != "/session/next" {
+		t.Fatalf("Location = %q, want root-origin redirect", got)
+	}
+}
+
+func TestInstanceProxyServiceRejectsLegacyOpenCodeSubpathProxy(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("legacy OpenCode request must not reach the runtime")
+	}))
+	defer upstream.Close()
+
+	service, token := newOpenCodeV2ProxyTestService(t, upstream.URL, 137, "igt_opencode_instance")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/instances/137/proxy/", nil)
+	if err := service.ProxyRequest(req.Context(), 137, token.Token, httptest.NewRecorder(), req); !errors.Is(err, ErrOpenCodeDedicatedOriginRequired) {
+		t.Fatalf("ProxyRequest error = %v, want ErrOpenCodeDedicatedOriginRequired", err)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/instances/137/proxy/ws", nil)
+	if err := service.ProxyWebSocket(req.Context(), 137, token.Token, httptest.NewRecorder(), req); !errors.Is(err, ErrOpenCodeDedicatedOriginRequired) {
+		t.Fatalf("ProxyWebSocket error = %v, want ErrOpenCodeDedicatedOriginRequired", err)
+	}
+}
+
 func TestInstanceProxyServiceNormalizesDeepSeekHarnessDedicatedWebSocketOrigin(t *testing.T) {
 	instanceToken := "igt_deepseek_harness_instance"
 	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
@@ -969,6 +1035,34 @@ func TestInstanceProxyServiceUsesConfiguredDedicatedOriginForDeepSeekHarnessLite
 	}
 }
 
+func TestInstanceProxyServiceRequiresConfiguredDedicatedOriginForOpenCodeLite(t *testing.T) {
+	workspacePath := "/workspaces/opencode/user-45/instance-123"
+	instance := &models.Instance{
+		ID: 123, Type: RuntimeTypeOpenCode, RuntimeType: RuntimeBackendGateway,
+		InstanceMode: InstanceModeLite, WorkspacePath: &workspacePath,
+	}
+	accessService := NewInstanceAccessService()
+	t.Cleanup(accessService.Stop)
+	service := NewInstanceProxyService(accessService)
+
+	t.Setenv(openCodePublicURLTemplateEnvVar, "https://opencode-{instance_id}.172-16-1-12.nip.io:39443/")
+	got := service.GetProxyURLForInstance(instance, "token+with/slash")
+	want := "https://opencode-123.172-16-1-12.nip.io:39443/?token=token%2Bwith%2Fslash"
+	if got != want {
+		t.Fatalf("GetProxyURLForInstance() = %q, want %q", got, want)
+	}
+
+	t.Setenv(openCodePublicURLTemplateEnvVar, "")
+	if got := service.GetProxyURLForInstance(instance, "token"); got != "" {
+		t.Fatalf("missing dedicated-origin template returned legacy proxy URL %q", got)
+	}
+
+	t.Setenv(openCodePublicURLTemplateEnvVar, "https://runtime.example.test/")
+	if got := service.GetProxyURLForInstance(instance, "token"); got != "" {
+		t.Fatalf("invalid dedicated-origin template returned legacy proxy URL %q", got)
+	}
+}
+
 func TestInstanceProxyServiceUsesChatEntryForHermesLite(t *testing.T) {
 	workspacePath := "/workspaces/hermes/user-45/instance-123"
 	accessService := NewInstanceAccessService()
@@ -1187,6 +1281,28 @@ func newDeepSeekHarnessV2ProxyTestService(t *testing.T, upstreamURL string, inst
 		int64(instanceID): {ID: int64(instanceID), PodIP: &podIP, State: "ready"},
 	}}
 	return newV2ProxyTestService(t, instanceRepo, bindingRepo, podRepo, 45, instanceID, RuntimeTypeDeepSeekHarness)
+}
+
+func newOpenCodeV2ProxyTestService(t *testing.T, upstreamURL string, instanceID int, instanceToken string) (*InstanceProxyService, *AccessToken) {
+	t.Helper()
+	podIP, gatewayPort := splitURLHostPortForProxyTest(t, upstreamURL)
+	workspacePath := "/workspaces/opencode/user-45/instance-" + strconv.Itoa(instanceID)
+	instanceRepo := newV2LifecycleInstanceRepo()
+	instanceRepo.byID[instanceID] = &models.Instance{
+		ID: instanceID, UserID: 45, Type: RuntimeTypeOpenCode,
+		RuntimeType: RuntimeBackendGateway, InstanceMode: InstanceModeLite,
+		Status: "running", AccessToken: &instanceToken, WorkspacePath: &workspacePath,
+		RuntimeGeneration: 1,
+	}
+	bindingRepo := newFakeRuntimeBindingRepo()
+	bindingRepo.bindings[instanceID] = &models.InstanceRuntimeBinding{
+		InstanceID: instanceID, RuntimePodID: int64(instanceID), GatewayPort: gatewayPort,
+		State: "running", Generation: 1,
+	}
+	podRepo := &fakeRuntimePodRepo{pods: map[int64]*models.RuntimePod{
+		int64(instanceID): {ID: int64(instanceID), PodIP: &podIP, State: "ready"},
+	}}
+	return newV2ProxyTestService(t, instanceRepo, bindingRepo, podRepo, 45, instanceID, RuntimeTypeOpenCode)
 }
 
 func splitURLHostPortForProxyTest(t *testing.T, rawURL string) (string, int) {

--- a/backend/internal/services/opencode_proxy_test.go
+++ b/backend/internal/services/opencode_proxy_test.go
@@ -102,7 +102,8 @@ func TestIsOpenCodeLiteProxyInstance(t *testing.T) {
 	}
 }
 
-func TestGetProxyURLForInstanceOpenCodeLiteUsesRoot(t *testing.T) {
+func TestGetProxyURLForInstanceOpenCodeLiteUsesDedicatedOrigin(t *testing.T) {
+	t.Setenv(openCodePublicURLTemplateEnvVar, "https://opencode-{instance_id}.runtime.example.test/")
 	workspacePath := "/workspaces/opencode/user-45/instance-123"
 	accessService := NewInstanceAccessService()
 	t.Cleanup(accessService.Stop)
@@ -115,7 +116,7 @@ func TestGetProxyURLForInstanceOpenCodeLiteUsesRoot(t *testing.T) {
 		WorkspacePath: &workspacePath,
 	}, "token+with/slash")
 
-	want := "/api/v1/instances/123/proxy/?token=token%2Bwith%2Fslash"
+	want := "https://opencode-123.runtime.example.test/?token=token%2Bwith%2Fslash"
 	if got != want {
 		t.Fatalf("GetProxyURLForInstance() = %q, want %q", got, want)
 	}

--- a/deployments/k3s/cluster/clawmanager.yaml
+++ b/deployments/k3s/cluster/clawmanager.yaml
@@ -6245,6 +6245,11 @@ spec:
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: CLAWMANAGER_DESKTOP_DIRECT_PROXY
               value: "true"
+            # Required for the OpenCode Lite per-instance browser origin. Set
+            # this to a nip.io or private wildcard-DNS URL template; the
+            # {instance_id} placeholder is mandatory. See docs/deployment.md.
+            - name: CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE
+              value: ""
             # Required for the DeepSeek Harness Lite root-origin UI. The
             # {instance_id} placeholder is required; see docs/deployment.md.
             - name: CLAWMANAGER_DEEPSEEK_HARNESS_PUBLIC_URL_TEMPLATE

--- a/deployments/k3s/single-node/clawmanager.yaml
+++ b/deployments/k3s/single-node/clawmanager.yaml
@@ -1390,6 +1390,11 @@ spec:
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: CLAWMANAGER_DESKTOP_DIRECT_PROXY
               value: "true"
+            # Required for the OpenCode Lite per-instance browser origin. Set
+            # this to a nip.io or private wildcard-DNS URL template; the
+            # {instance_id} placeholder is mandatory. See docs/deployment.md.
+            - name: CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE
+              value: ""
             # Required for the DeepSeek Harness Lite root-origin UI. The
             # {instance_id} placeholder is required; see docs/deployment.md.
             - name: CLAWMANAGER_DEEPSEEK_HARNESS_PUBLIC_URL_TEMPLATE

--- a/deployments/k8s/cluster/clawmanager.yaml
+++ b/deployments/k8s/cluster/clawmanager.yaml
@@ -6245,6 +6245,11 @@ spec:
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: CLAWMANAGER_DESKTOP_DIRECT_PROXY
               value: "true"
+            # Required for the OpenCode Lite per-instance browser origin. Set
+            # this to a nip.io or private wildcard-DNS URL template; the
+            # {instance_id} placeholder is mandatory. See docs/deployment.md.
+            - name: CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE
+              value: ""
             # Required for the DeepSeek Harness Lite root-origin UI. The
             # {instance_id} placeholder is required; see docs/deployment.md.
             - name: CLAWMANAGER_DEEPSEEK_HARNESS_PUBLIC_URL_TEMPLATE

--- a/deployments/k8s/install-local-nipio-tls.ps1
+++ b/deployments/k8s/install-local-nipio-tls.ps1
@@ -1,0 +1,207 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param(
+    [string]$Namespace = 'clawmanager-system',
+    [string]$SecretName = 'clawmanager-tls',
+    [string]$GeneratorDeployment = 'clawmanager-app',
+    [string]$NipIoSuffix = '127-0-0-1.nip.io',
+    [string]$CommonName = 'localhost',
+    [ValidateRange(1, 36500)]
+    [int]$ValidityDays = 3650,
+    [string]$KubeContext = 'docker-desktop',
+    [string]$Kubeconfig = "$env:USERPROFILE\.kube\config",
+    [string]$OutputDirectory = "$env:TEMP\clawmanager-nipio-tls",
+    [switch]$TrustCurrentUser,
+    [switch]$SkipRolloutWait
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ($NipIoSuffix -notmatch '^[a-zA-Z0-9.-]+$' -or $NipIoSuffix.StartsWith('.') -or $NipIoSuffix.EndsWith('.')) {
+    throw "Invalid nip.io suffix: $NipIoSuffix"
+}
+if ($Namespace -notmatch '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$') {
+    throw "Invalid Kubernetes namespace: $Namespace"
+}
+if ($SecretName -notmatch '^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$') {
+    throw "Invalid Kubernetes Secret name: $SecretName"
+}
+
+$kubectlBaseArgs = @()
+if ($Kubeconfig) {
+    $kubectlBaseArgs += @('--kubeconfig', $Kubeconfig)
+}
+if ($KubeContext) {
+    $kubectlBaseArgs += @('--context', $KubeContext)
+}
+
+function Invoke-Kubectl {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [switch]$AllowNotFound
+    )
+
+    $output = & kubectl @kubectlBaseArgs @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $message = ($output | Out-String).Trim()
+        if ($AllowNotFound -and $message -match 'NotFound') {
+            return $null
+        }
+        throw "kubectl $($Arguments -join ' ') failed:`n$message"
+    }
+    return $output
+}
+
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+    throw 'kubectl was not found in PATH.'
+}
+if ($Kubeconfig -and -not (Test-Path -LiteralPath $Kubeconfig)) {
+    throw "Kubeconfig does not exist: $Kubeconfig"
+}
+
+$dnsNames = @(
+    'localhost',
+    'clawmanager.local',
+    $NipIoSuffix,
+    "*.$NipIoSuffix"
+) | Select-Object -Unique
+
+$sanParts = @($dnsNames | ForEach-Object { "DNS:$_" }) + 'IP:127.0.0.1'
+$subjectAltName = $sanParts -join ','
+$remoteDirectory = "/tmp/clawmanager-tls-$([Guid]::NewGuid().ToString('N'))"
+$deploymentRef = "deployment/$GeneratorDeployment"
+
+Write-Host "Target Secret : $Namespace/$SecretName"
+Write-Host "Certificate   : $subjectAltName"
+Write-Host "Generator     : $Namespace/$deploymentRef"
+
+Invoke-Kubectl -Arguments @('version', '--client=true') | Out-Null
+Invoke-Kubectl -Arguments @('-n', $Namespace, 'get', $deploymentRef, '-o', 'name') | Out-Null
+
+if (-not $PSCmdlet.ShouldProcess("$Namespace/$SecretName", 'Generate and install a new TLS certificate')) {
+    return
+}
+
+$remoteScript = @'
+set -eu
+target="$1"
+common_name="$2"
+subject_alt_name="$3"
+validity_days="$4"
+umask 077
+mkdir -p "$target"
+openssl req -x509 -nodes -newkey rsa:2048 \
+  -days "$validity_days" \
+  -subj "/CN=$common_name" \
+  -addext "subjectAltName=$subject_alt_name" \
+  -addext "keyUsage=critical,digitalSignature,keyEncipherment" \
+  -addext "extendedKeyUsage=serverAuth" \
+  -keyout "$target/tls.key" \
+  -out "$target/tls.crt"
+openssl x509 -in "$target/tls.crt" -noout -subject -dates -ext subjectAltName
+'@
+
+try {
+    Write-Host 'Generating certificate inside the ClawManager pod...'
+    Invoke-Kubectl -Arguments @(
+        '-n', $Namespace, 'exec', $deploymentRef, '--',
+        'sh', '-c', $remoteScript, 'sh', $remoteDirectory, $CommonName, $subjectAltName, $ValidityDays.ToString()
+    ) | ForEach-Object { Write-Host $_ }
+
+    $certificateBase64 = (Invoke-Kubectl -Arguments @(
+        '-n', $Namespace, 'exec', $deploymentRef, '--',
+        'sh', '-c', 'base64 "$1/tls.crt" | tr -d "\n"', 'sh', $remoteDirectory
+    ) | Out-String).Trim()
+    $privateKeyBase64 = (Invoke-Kubectl -Arguments @(
+        '-n', $Namespace, 'exec', $deploymentRef, '--',
+        'sh', '-c', 'base64 "$1/tls.key" | tr -d "\n"', 'sh', $remoteDirectory
+    ) | Out-String).Trim()
+
+    if (-not $certificateBase64 -or -not $privateKeyBase64) {
+        throw 'The generated certificate or private key was empty.'
+    }
+
+    New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $backupPath = Join-Path $OutputDirectory "$SecretName-$timestamp.backup.yaml"
+    $certificatePath = Join-Path $OutputDirectory 'tls.crt'
+
+    $existingSecret = Invoke-Kubectl -Arguments @(
+        '-n', $Namespace, 'get', 'secret', $SecretName, '-o', 'yaml'
+    ) -AllowNotFound
+    if ($null -ne $existingSecret) {
+        $existingSecret | Set-Content -LiteralPath $backupPath -Encoding UTF8
+        Write-Host "Existing Secret backup: $backupPath"
+    }
+
+    [IO.File]::WriteAllBytes($certificatePath, [Convert]::FromBase64String($certificateBase64))
+
+    $secretManifest = [ordered]@{
+        apiVersion = 'v1'
+        kind = 'Secret'
+        metadata = [ordered]@{
+            name = $SecretName
+            namespace = $Namespace
+        }
+        type = 'kubernetes.io/tls'
+        data = [ordered]@{
+            'tls.crt' = $certificateBase64
+            'tls.key' = $privateKeyBase64
+        }
+    } | ConvertTo-Json -Depth 8
+
+    $secretManifest | & kubectl @kubectlBaseArgs apply -f -
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to apply Secret $Namespace/$SecretName."
+    }
+
+    $deploymentsJson = (Invoke-Kubectl -Arguments @(
+        '-n', $Namespace, 'get', 'deployments', '-o', 'json'
+    ) | Out-String) | ConvertFrom-Json
+
+    $consumers = @($deploymentsJson.items | Where-Object {
+        @($_.spec.template.spec.volumes | Where-Object {
+            $secretProperty = $_.PSObject.Properties['secret']
+            $null -ne $secretProperty -and $secretProperty.Value.secretName -eq $SecretName
+        }).Count -gt 0
+    } | ForEach-Object { $_.metadata.name })
+
+    if ($consumers.Count -eq 0) {
+        Write-Warning "No Deployment in namespace $Namespace directly mounts Secret $SecretName. Restart the TLS endpoint manually if it reads the Secret another way."
+    } else {
+        foreach ($deployment in $consumers) {
+            Write-Host "Restarting deployment/$deployment..."
+            Invoke-Kubectl -Arguments @('-n', $Namespace, 'rollout', 'restart', "deployment/$deployment") |
+                ForEach-Object { Write-Host $_ }
+        }
+        if (-not $SkipRolloutWait) {
+            foreach ($deployment in $consumers) {
+                Invoke-Kubectl -Arguments @(
+                    '-n', $Namespace, 'rollout', 'status', "deployment/$deployment", '--timeout=5m'
+                ) | ForEach-Object { Write-Host $_ }
+            }
+        }
+    }
+
+    if ($TrustCurrentUser) {
+        Write-Warning 'This trusts the self-signed certificate for the current Windows user.'
+        Import-Certificate -FilePath $certificatePath -CertStoreLocation 'Cert:\CurrentUser\Root' | Out-Null
+        Write-Host 'Certificate imported into Cert:\CurrentUser\Root.'
+    }
+
+    Write-Host ''
+    Write-Host 'TLS deployment completed.' -ForegroundColor Green
+    Write-Host "Certificate copy: $certificatePath"
+    Write-Host "Test URL       : https://opencode-1.$NipIoSuffix`:8443/"
+}
+finally {
+    try {
+        Invoke-Kubectl -Arguments @(
+            '-n', $Namespace, 'exec', $deploymentRef, '--',
+            'sh', '-c', 'rm -rf -- "$1"', 'sh', $remoteDirectory
+        ) | Out-Null
+    } catch {
+        Write-Warning "Could not remove temporary pod files at ${remoteDirectory}: $($_.Exception.Message)"
+    }
+}

--- a/deployments/k8s/single-node/README.md
+++ b/deployments/k8s/single-node/README.md
@@ -116,6 +116,24 @@ clients. DNS, TLS, and verification requirements are documented in the
 kubectl apply -f clawmanager.yaml
 ```
 
+For a Docker Desktop installation exposed on `localhost:8443`, generate and
+install a self-signed certificate covering `*.127-0-0-1.nip.io` from Windows
+PowerShell:
+
+```powershell
+..\install-local-nipio-tls.ps1
+```
+
+To also trust that self-signed certificate for the current Windows user:
+
+```powershell
+..\install-local-nipio-tls.ps1 -TrustCurrentUser
+```
+
+The script backs up the existing `clawmanager-tls` Secret under the current
+user's temporary directory, updates the Secret, and restarts every Deployment
+in `clawmanager-system` that directly mounts it.
+
 ### 7. Check ClawManager
 
 ```sh

--- a/deployments/k8s/single-node/clawmanager.yaml
+++ b/deployments/k8s/single-node/clawmanager.yaml
@@ -1392,6 +1392,11 @@ spec:
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: CLAWMANAGER_DESKTOP_DIRECT_PROXY
               value: "true"
+            # Required for the OpenCode Lite per-instance browser origin. Set
+            # this to a nip.io or private wildcard-DNS URL template; the
+            # {instance_id} placeholder is mandatory. See docs/deployment.md.
+            - name: CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE
+              value: ""
             # Required for the DeepSeek Harness Lite root-origin UI. The
             # {instance_id} placeholder is required; see docs/deployment.md.
             - name: CLAWMANAGER_DEEPSEEK_HARNESS_PUBLIC_URL_TEMPLATE

--- a/deployments/nginx/nginx.conf
+++ b/deployments/nginx/nginx.conf
@@ -151,6 +151,9 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Forwarded-Prefix /api/v1/instances/$inst_id/proxy;
+            # Dedicated-origin trust is asserted only by the runtime virtual
+            # hosts below, never by a client using the legacy public path.
+            proxy_set_header X-ClawManager-Runtime-Origin "";
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             # Browsers may include the original iframe URL (with ?token=...)
@@ -176,6 +179,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
+            # Only dedicated runtime virtual hosts may assert this internal
+            # routing marker; discard any value supplied by public clients.
+            proxy_set_header X-ClawManager-Runtime-Origin "";
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_connect_timeout 15s;
@@ -187,6 +193,61 @@ http {
         }
 
         location @desktop_denied {
+            add_header Content-Type text/plain always;
+            return 401 "Access token expired or invalid";
+        }
+    }
+
+    # OpenCode's built-in web UI owns the root of its browser origin. Give
+    # every logical Lite instance a distinct virtual host while the processes
+    # continue to share the managed runtime pool. The instance ID captured
+    # from the hostname is authenticated against the signed access token.
+    server {
+        listen 8443 ssl;
+        http2 on;
+        server_name ~^opencode-(?<runtime_inst_id>[0-9]+)\..+$;
+
+        ssl_certificate /etc/nginx/tls/tls.crt;
+        ssl_certificate_key /etc/nginx/tls/tls.key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers off;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 1d;
+
+        client_max_body_size 500m;
+
+        location / {
+            js_set $desktop_target desktop.resolveTarget;
+
+            error_page 463 = @opencode_origin_denied;
+            if ($desktop_target = "deny") {
+                return 463;
+            }
+
+            # Preserve a root-origin browser contract. The internal rewrite is
+            # never exposed to the browser; the control plane resolves the
+            # current shared-pool binding and injects OpenCode Basic auth.
+            rewrite ^(.*)$ /api/v1/instances/$runtime_inst_id/proxy$1 break;
+
+            proxy_pass http://clawreef_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-ClawManager-Runtime-Origin opencode;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Referer "";
+            proxy_connect_timeout 15s;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+            proxy_buffering off;
+            proxy_request_buffering off;
+        }
+
+        location @opencode_origin_denied {
             add_header Content-Type text/plain always;
             return 401 "Access token expired or invalid";
         }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,6 +64,52 @@ kubectl get pvc -n clawmanager-system
 kubectl get pods -n clawmanager-system
 ```
 
+## OpenCode Lite Per-Instance Origins
+
+OpenCode Lite must use a dedicated browser origin for every logical instance,
+even though its process still runs in the shared `opencode-runtime` pool. Set:
+
+```text
+CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE=https://opencode-{instance_id}.172-16-1-12.nip.io:39443/
+```
+
+The value must be an absolute HTTP(S) URL containing `{instance_id}`. For
+instance `172`, the example above produces:
+
+```text
+https://opencode-172.172-16-1-12.nip.io:39443/
+```
+
+The browser remains at the root of that origin; it never receives the legacy
+`/api/v1/instances/{id}/proxy/` URL. The edge gateway validates the short-lived
+instance token, stores it in an origin-scoped secure cookie, and routes the
+request to the instance's current shared-pool process. An empty or invalid
+template is a deployment error and OpenCode Lite access URL generation fails
+instead of falling back to the legacy subpath proxy.
+
+`nip.io` supplies wildcard DNS only. The TLS certificate served by the
+ClawManager gateway must cover the generated names, for example
+`*.172-16-1-12.nip.io`, and clients must trust its issuing CA.
+
+For offline networks, point a wildcard zone at the ClawManager gateway and use
+a template such as:
+
+```text
+CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE=https://opencode-{instance_id}.clawmanager.test:39443/
+```
+
+The gateway certificate must then include `*.clawmanager.test`. Existing
+instances do not need to be recreated after changing the template; access URLs
+are generated when access is requested.
+
+Apply the selected value before enabling OpenCode Lite:
+
+```bash
+kubectl -n clawmanager-system set env deployment/clawmanager-app \
+  'CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE=https://opencode-{instance_id}.clawmanager.test:39443/'
+kubectl -n clawmanager-system rollout status deployment/clawmanager-app
+```
+
 ## DeepSeek Harness Runtime
 
 DeepSeek Harness is available in both runtime modes:


### PR DESCRIPTION
## Summary

- expose every OpenCode Lite instance on its own browser origin
- require `CLAWMANAGER_OPENCODE_PUBLIC_URL_TEMPLATE` instead of falling back to the legacy public subpath proxy
- bootstrap an origin-scoped secure cookie and strip the one-time access token from the visible URL
- add wildcard-DNS/TLS deployment guidance and a local nip.io certificate helper

## Validation

- `go test ./...`
- PowerShell parser validation for `install-local-nipio-tls.ps1`
- Nginx configuration validation in the test image

## Scope

This PR contains only the OpenCode dedicated-origin changes. Local LiteLLM / AI Gateway work is intentionally excluded.