### PR TITLE
fix(opencode): use web UI for Lite instances

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -207,7 +207,7 @@ func main() {
 		skillService,
 		externalAccessService,
 		aiObservabilityService,
-		services.NewInstanceShellService(runtimePodRepo, bindingRepo),
+		services.NewInstanceShellService(),
 		services.WithInstanceProxyRuntimeRepositories(instanceRepo, runtimePodRepo, bindingRepo),
 	)
 	systemSettingsHandler := handlers.NewSystemSettingsHandler(systemImageSettingService)

--- a/backend/internal/handlers/instance_handler.go
+++ b/backend/internal/handlers/instance_handler.go
@@ -1567,8 +1567,8 @@ func (h *InstanceHandler) StreamShell(c *gin.Context) {
 		return
 	}
 
-	if !strings.EqualFold(strings.TrimSpace(instance.RuntimeType), "shell") && !services.IsOpenCodeLiteTUIInstance(instance) {
-		utils.Error(c, http.StatusBadRequest, "Shell access is only available for shell or OpenCode Lite instances")
+	if !strings.EqualFold(strings.TrimSpace(instance.RuntimeType), "shell") {
+		utils.Error(c, http.StatusBadRequest, "Shell access is only available for shell instances")
 		return
 	}
 

--- a/backend/internal/services/instance_shell_service.go
+++ b/backend/internal/services/instance_shell_service.go
@@ -6,27 +6,22 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 
 	"clawreef/internal/models"
-	"clawreef/internal/repository"
 	"clawreef/internal/services/k8s"
 
 	"github.com/gorilla/websocket"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
 // InstanceShellService streams an interactive shell into an instance pod.
 type InstanceShellService struct {
-	podService     *k8s.PodService
-	runtimePodRepo repository.RuntimePodRepository
-	bindingRepo    repository.InstanceRuntimeBindingRepository
-	upgrader       websocket.Upgrader
+	podService *k8s.PodService
+	upgrader   websocket.Upgrader
 }
 
 type shellClientMessage struct {
@@ -48,11 +43,9 @@ type shellWebSocketWriter struct {
 	done <-chan struct{}
 }
 
-func NewInstanceShellService(runtimePodRepo repository.RuntimePodRepository, bindingRepo repository.InstanceRuntimeBindingRepository) *InstanceShellService {
+func NewInstanceShellService() *InstanceShellService {
 	return &InstanceShellService{
-		podService:     k8s.NewPodService(),
-		runtimePodRepo: runtimePodRepo,
-		bindingRepo:    bindingRepo,
+		podService: k8s.NewPodService(),
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool { return true },
 		},
@@ -132,22 +125,8 @@ func (s *InstanceShellService) execTarget(ctx context.Context, instance *models.
 	if instance == nil {
 		return nil, "", nil, fmt.Errorf("instance is required")
 	}
-	if IsOpenCodeLiteTUIInstance(instance) {
-		if s.bindingRepo == nil || s.runtimePodRepo == nil {
-			return nil, "", nil, fmt.Errorf("runtime terminal lookup is not configured")
-		}
-		binding, err := s.bindingRepo.GetRunningByInstanceID(ctx, instance.ID)
-		if err != nil || binding == nil {
-			return nil, "", nil, fmt.Errorf("OpenCode runtime gateway is unavailable")
-		}
-		if binding.Generation != instance.RuntimeGeneration {
-			return nil, "", nil, fmt.Errorf("OpenCode runtime gateway is stale")
-		}
-		runtimePod, err := s.runtimePodRepo.GetByID(ctx, binding.RuntimePodID)
-		if err != nil || runtimePod == nil || strings.TrimSpace(runtimePod.PodName) == "" || strings.TrimSpace(runtimePod.Namespace) == "" {
-			return nil, "", nil, fmt.Errorf("OpenCode runtime pod is unavailable")
-		}
-		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: runtimePod.PodName, Namespace: runtimePod.Namespace}}, "runtime", openCodeTUICommand(instance, binding), nil
+	if !strings.EqualFold(strings.TrimSpace(instance.RuntimeType), RuntimeBackendShell) {
+		return nil, "", nil, fmt.Errorf("shell access is only available for shell instances")
 	}
 
 	pod, err := s.podService.GetPod(ctx, instance.UserID, instance.ID)
@@ -155,49 +134,6 @@ func (s *InstanceShellService) execTarget(ctx context.Context, instance *models.
 		return nil, "", nil, err
 	}
 	return pod, "desktop", defaultShellCommand(), nil
-}
-
-func IsOpenCodeLiteTUIInstance(instance *models.Instance) bool {
-	return instance != nil &&
-		strings.EqualFold(strings.TrimSpace(instance.Type), RuntimeTypeOpenCode) &&
-		strings.EqualFold(strings.TrimSpace(instance.InstanceMode), InstanceModeLite) &&
-		strings.EqualFold(strings.TrimSpace(instance.RuntimeType), RuntimeBackendGateway)
-}
-
-func openCodeTUICommand(instance *models.Instance, binding *models.InstanceRuntimeBinding) []string {
-	workspace := ""
-	if instance != nil && instance.WorkspacePath != nil {
-		workspace = strings.TrimSpace(*instance.WorkspacePath)
-	}
-	if workspace == "" && instance != nil {
-		workspace = RuntimeWorkspacePath(RuntimeTypeOpenCode, instance.UserID, instance.ID)
-	}
-	home := workspace + "/home"
-	uid := RuntimeLinuxID(instance.ID)
-	gatewayPID := ""
-	if binding != nil && binding.GatewayPID != nil && *binding.GatewayPID > 0 {
-		gatewayPID = strconv.Itoa(*binding.GatewayPID)
-	} else if instance != nil {
-		// The gateway is owned by the same per-instance Linux user. Reading its
-		// environment after dropping privileges is permitted and supplies the
-		// API key referenced by the generated OpenCode config.
-		gatewayPID = "$(pgrep -u " + strconv.Itoa(uid) + " -f '/usr/local/bin/opencode web' | head -n 1)"
-	}
-	// Start the official TUI in the same per-instance home directory as the
-	// gateway. Running it directly avoids reading the gateway's private
-	// credentials from /proc, which is blocked by the runtime's process
-	// isolation. The TUI still loads the same per-instance provider config.
-	command := "/usr/local/bin/opencode " + shellQuoteForTerminal(workspace)
-	script := "exec setpriv --reuid=" + strconv.Itoa(uid) + " --regid=" + strconv.Itoa(uid) + " --clear-groups sh -lc " + shellQuoteForTerminal(
-		"gateway_pid="+shellQuoteForTerminal(gatewayPID)+"; "+
-			"if [ -n \"$gateway_pid\" ]; then export $(tr '\\000' '\\n' </proc/$gateway_pid/environ | grep '^CLAWMANAGER_LLM_API_KEY=' || true); fi; "+
-			"export HOME="+shellQuoteForTerminal(home)+" OPENCODE_CONFIG_DIR="+shellQuoteForTerminal(home+"/.opencode")+" OPENCODE_CONFIG="+shellQuoteForTerminal(home+"/.opencode/opencode.json")+" TERM=${TERM:-xterm-256color} COLORTERM=${COLORTERM:-truecolor}; exec "+command,
-	)
-	return []string{"sh", "-lc", script}
-}
-
-func shellQuoteForTerminal(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func defaultShellCommand() []string {

--- a/backend/internal/services/instance_shell_service_test.go
+++ b/backend/internal/services/instance_shell_service_test.go
@@ -1,0 +1,24 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"clawreef/internal/models"
+)
+
+func TestInstanceShellServiceRejectsOpenCodeLiteTUI(t *testing.T) {
+	service := &InstanceShellService{}
+	instance := &models.Instance{
+		ID:           42,
+		Type:         RuntimeTypeOpenCode,
+		RuntimeType:  RuntimeBackendGateway,
+		InstanceMode: InstanceModeLite,
+	}
+
+	_, _, _, err := service.execTarget(context.Background(), instance)
+	if err == nil || !strings.Contains(err.Error(), "only available for shell instances") {
+		t.Fatalf("execTarget() error = %v, want shell-only rejection", err)
+	}
+}

--- a/frontend/scripts/instance-portal-mode-layout.test.mjs
+++ b/frontend/scripts/instance-portal-mode-layout.test.mjs
@@ -49,6 +49,19 @@ assert(
 );
 
 assert(
+  portalSource.includes(
+    'const isShellPortal = selectedRuntimeType === "shell";',
+  ),
+  "OpenCode Lite must use its dedicated browser origin instead of the shell portal.",
+);
+
+assert(
+  !serviceFrameSource.includes("isOpenCodeLite") &&
+    !serviceFrameSource.includes("<InstanceShellTerminal"),
+  "OpenCode Lite service frames must not fall back to the terminal TUI.",
+);
+
+assert(
   portalSource.includes("xl:grid-rows-[minmax(0,1fr)]") &&
     portalSource.includes("xl:overflow-hidden") &&
     !portalSource.includes("content-start overflow-y-auto") &&

--- a/frontend/src/components/InstanceServiceFrame.tsx
+++ b/frontend/src/components/InstanceServiceFrame.tsx
@@ -5,7 +5,6 @@ import { useInstanceDesktopAccess } from "../hooks/useInstanceDesktopAccess";
 import { clearHermesDashboardStorage, prepareHermesDashboardStorage } from "../lib/hermesDashboardStorage";
 import { prepareOpenClawControlUIStorage } from "../lib/openclawControlStorage";
 import type { InstanceAvailability } from "../types/instance";
-import { InstanceShellTerminal } from "./InstanceShellTerminal";
 
 interface InstanceServiceFrameProps {
   instanceId: number;
@@ -45,7 +44,6 @@ export function InstanceServiceFrame({
   instanceId,
   instanceName,
   instanceType,
-  instanceMode,
   availability,
   reloadToken = 0,
   workspaceVisible,
@@ -58,8 +56,6 @@ export function InstanceServiceFrame({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const normalizedType = instanceType?.toLowerCase() ?? "";
   const isHermes = normalizedType === "hermes";
-  const isOpenCodeLite =
-    normalizedType === "opencode" && instanceMode?.toLowerCase() === "lite";
   const {
     embedUrl,
     loading,
@@ -191,19 +187,6 @@ export function InstanceServiceFrame({
       <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-slate-600">
         Unavailable
       </div>,
-    );
-  }
-
-  if (isOpenCodeLite) {
-    return (
-      <InstanceShellTerminal
-        instanceId={instanceId}
-        instanceName={instanceName}
-        isRunning={isAvailable}
-        autoConnect
-        heightClassName="h-full min-h-0 max-h-none"
-        className="h-full"
-      />
     );
   }
 

--- a/frontend/src/components/InstanceShellTerminal.tsx
+++ b/frontend/src/components/InstanceShellTerminal.tsx
@@ -214,8 +214,8 @@ export function InstanceShellTerminal({
     manuallyDisconnectedRef.current = false;
   }, [instanceId]);
 
-  // OpenCode Lite uses this terminal as its primary UI. Connect as soon as
-  // its xterm surface exists, while preserving a user's explicit disconnect.
+  // Auto-connect terminal consumers as soon as the xterm surface exists,
+  // while preserving a user's explicit disconnect.
   useEffect(() => {
     if (!autoConnect || !isRunning || !terminalElement || manuallyDisconnectedRef.current) {
       return;

--- a/frontend/src/pages/instances/InstancePortalPage.tsx
+++ b/frontend/src/pages/instances/InstancePortalPage.tsx
@@ -185,14 +185,9 @@ const InstancePortalPage: React.FC = () => {
   const selectedInstanceId = selectedInstance?.id ?? null;
   const selectedInstanceStatus = selectedInstance?.status ?? null;
   const selectedRuntimeType = selectedInstance?.runtime_type ?? "desktop";
-  // The Lite OpenCode web client is currently unreliable behind a prefixed
-  // reverse proxy. Use the official terminal UI instead; it connects directly
-  // to the same per-instance gateway and provider configuration.
-  const isShellPortal =
-    selectedRuntimeType === "shell" ||
-    (selectedInstance?.type === "opencode" &&
-      selectedInstance.instance_mode === "lite" &&
-      selectedRuntimeType === "gateway");
+  // OpenCode Lite owns a dedicated per-instance origin, so it must use the
+  // regular browser access flow. Only an actual shell runtime uses the TUI.
+  const isShellPortal = selectedRuntimeType === "shell";
   const isProPortal = Boolean(
     selectedInstance && selectedInstance.instance_mode === "pro",
   );


### PR DESCRIPTION
## Summary
- remove the OpenCode Lite terminal/TUI fallback from the instance portal and service frame
- load OpenCode Lite exclusively through its dedicated per-instance browser origin
- reject OpenCode Lite Shell WebSocket access in both the handler and service layers
- remove the backend command path that launched bare OpenCode TUI processes
- keep terminal rendering and shell streaming only for actual shell runtimes
- add frontend and backend regression coverage

## Validation
- node scripts/instance-portal-mode-layout.test.mjs
- npm run build
- targeted OpenCode and Shell Go tests
- full Go suite passes except the existing Windows CRLF-sensitive migration 049 assertion

## Scope
This PR contains only the OpenCode Lite Web-only access changes. LiteLLM / AI Gateway work is excluded.