### PR TITLE
fix(deploy): configure Hermes Desktop Web

### DIFF
--- a/backend/internal/db/runtime_manifest_test.go
+++ b/backend/internal/db/runtime_manifest_test.go
@@ -49,7 +49,10 @@ func TestDeploymentManifestsConfigureHermesDesktopWeb(t *testing.T) {
 		"clawmanager-app": "clawmanager-app",
 		"hermes-runtime":  "runtime",
 	}
-	const wantOrigin = "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+	const (
+		wantOrigin      = "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+		wantHermesImage = "ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44"
+	)
 
 	for _, manifest := range deploymentRuntimeManifests(repoRoot) {
 		t.Run(manifest, func(t *testing.T) {
@@ -71,8 +74,9 @@ func TestDeploymentManifestsConfigureHermesDesktopWeb(t *testing.T) {
 						Template struct {
 							Spec struct {
 								Containers []struct {
-									Name string `yaml:"name"`
-									Env  []struct {
+									Name  string `yaml:"name"`
+									Image string `yaml:"image"`
+									Env   []struct {
 										Name  string `yaml:"name"`
 										Value string `yaml:"value"`
 									} `yaml:"env"`
@@ -105,6 +109,21 @@ func TestDeploymentManifestsConfigureHermesDesktopWeb(t *testing.T) {
 					}
 					if got := environment["CLAWMANAGER_CONTROL_UI_ORIGIN"]; got != wantOrigin {
 						t.Fatalf("%s has unexpected Hermes control UI origin %q", document.Metadata.Name, got)
+					}
+					if document.Metadata.Name == "hermes-runtime" {
+						if container.Image != wantHermesImage {
+							t.Fatalf("Hermes runtime must use immutable image %q, got %q", wantHermesImage, container.Image)
+						}
+						if got := environment["CLAWMANAGER_RUNTIME_IMAGE_REF"]; got != wantHermesImage {
+							t.Fatalf("Hermes runtime must report immutable image ref %q, got %q", wantHermesImage, got)
+						}
+						wantProxyCIDR := "10.244.0.0/16"
+						if strings.Contains(filepath.Clean(manifest), filepath.Join("deployments", "k3s")) {
+							wantProxyCIDR = "10.42.0.0/16"
+						}
+						if got := environment["CLAWMANAGER_TRUSTED_PROXY_CIDRS"]; got != wantProxyCIDR {
+							t.Fatalf("Hermes runtime has unexpected trusted proxy CIDR %q", got)
+						}
 					}
 				}
 			}

--- a/backend/internal/db/runtime_manifest_test.go
+++ b/backend/internal/db/runtime_manifest_test.go
@@ -43,6 +43,81 @@ func TestRuntimeManifestsAreValidYAML(t *testing.T) {
 	}
 }
 
+func TestDeploymentManifestsConfigureHermesDesktopWeb(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	wantDeployments := map[string]string{
+		"clawmanager-app": "clawmanager-app",
+		"hermes-runtime":  "runtime",
+	}
+	const wantOrigin = "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+
+	for _, manifest := range deploymentRuntimeManifests(repoRoot) {
+		t.Run(manifest, func(t *testing.T) {
+			file, err := os.Open(manifest)
+			if err != nil {
+				t.Fatalf("open manifest: %v", err)
+			}
+			defer file.Close()
+
+			found := make(map[string]bool, len(wantDeployments))
+			decoder := yaml.NewDecoder(file)
+			for {
+				var document struct {
+					Kind     string `yaml:"kind"`
+					Metadata struct {
+						Name string `yaml:"name"`
+					} `yaml:"metadata"`
+					Spec struct {
+						Template struct {
+							Spec struct {
+								Containers []struct {
+									Name string `yaml:"name"`
+									Env  []struct {
+										Name  string `yaml:"name"`
+										Value string `yaml:"value"`
+									} `yaml:"env"`
+								} `yaml:"containers"`
+							} `yaml:"spec"`
+						} `yaml:"template"`
+					} `yaml:"spec"`
+				}
+				if err := decoder.Decode(&document); err == io.EOF {
+					break
+				} else if err != nil {
+					t.Fatalf("parse manifest: %v", err)
+				}
+
+				containerName, wanted := wantDeployments[document.Metadata.Name]
+				if document.Kind != "Deployment" || !wanted {
+					continue
+				}
+				for _, container := range document.Spec.Template.Spec.Containers {
+					if container.Name != containerName {
+						continue
+					}
+					found[document.Metadata.Name] = true
+					environment := make(map[string]string, len(container.Env))
+					for _, variable := range container.Env {
+						environment[variable.Name] = variable.Value
+					}
+					if environment["CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED"] != "true" {
+						t.Fatalf("%s must explicitly enable Hermes Desktop Web", document.Metadata.Name)
+					}
+					if got := environment["CLAWMANAGER_CONTROL_UI_ORIGIN"]; got != wantOrigin {
+						t.Fatalf("%s has unexpected Hermes control UI origin %q", document.Metadata.Name, got)
+					}
+				}
+			}
+
+			for deployment := range wantDeployments {
+				if !found[deployment] {
+					t.Fatalf("manifest does not contain configured %s deployment", deployment)
+				}
+			}
+		})
+	}
+}
+
 func TestNineNodeProductionDatabaseLoadControls(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	manifest := filepath.Join(repoRoot, "deployments", "k8s", "sites", "nine-node-production", "20-clawmanager-production.yaml")

--- a/deployments/k3s/cluster/clawmanager.yaml
+++ b/deployments/k3s/cluster/clawmanager.yaml
@@ -6247,6 +6247,10 @@ spec:
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: TEAM_REDIS_URL
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
+            - name: CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED
+              value: "true"
+            - name: CLAWMANAGER_CONTROL_UI_ORIGIN
+              value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
             - name: CLAWMANAGER_DESKTOP_DIRECT_PROXY
               value: "true"
             # Required for the OpenCode Lite root-origin UI. The {instance_id}
@@ -6448,6 +6452,10 @@ spec:
             - name: CLAWMANAGER_RUNTIME_TYPE
               value: hermes
             - name: CLAWMANAGER_BACKEND_URL
+              value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+            - name: CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED
+              value: "true"
+            - name: CLAWMANAGER_CONTROL_UI_ORIGIN
               value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
             - name: CLAWMANAGER_RUNTIME_DEPLOYMENT_NAME
               value: hermes-runtime

--- a/deployments/k3s/cluster/clawmanager.yaml
+++ b/deployments/k3s/cluster/clawmanager.yaml
@@ -6446,7 +6446,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+          image: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44
           imagePullPolicy: IfNotPresent
           env:
             - name: CLAWMANAGER_RUNTIME_TYPE
@@ -6457,10 +6457,14 @@ spec:
               value: "true"
             - name: CLAWMANAGER_CONTROL_UI_ORIGIN
               value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+            # k3s uses 10.42.0.0/16 by default. Update this value when the
+            # cluster was installed with a different Pod CIDR.
+            - name: CLAWMANAGER_TRUSTED_PROXY_CIDRS
+              value: "10.42.0.0/16"
             - name: CLAWMANAGER_RUNTIME_DEPLOYMENT_NAME
               value: hermes-runtime
             - name: CLAWMANAGER_RUNTIME_IMAGE_REF
-              value: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+              value: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44
             - name: CLAWMANAGER_AGENT_PORT
               value: "19090"
             - name: CLAWMANAGER_GATEWAY_PORT_START

--- a/deployments/k3s/single-node/clawmanager.yaml
+++ b/deployments/k3s/single-node/clawmanager.yaml
@@ -1604,7 +1604,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+          image: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44
           imagePullPolicy: IfNotPresent
           env:
             - name: CLAWMANAGER_RUNTIME_TYPE
@@ -1615,10 +1615,14 @@ spec:
               value: "true"
             - name: CLAWMANAGER_CONTROL_UI_ORIGIN
               value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+            # k3s uses 10.42.0.0/16 by default. Update this value when the
+            # cluster was installed with a different Pod CIDR.
+            - name: CLAWMANAGER_TRUSTED_PROXY_CIDRS
+              value: "10.42.0.0/16"
             - name: CLAWMANAGER_RUNTIME_DEPLOYMENT_NAME
               value: hermes-runtime
             - name: CLAWMANAGER_RUNTIME_IMAGE_REF
-              value: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+              value: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44
             - name: CLAWMANAGER_AGENT_PORT
               value: "19090"
             - name: CLAWMANAGER_GATEWAY_PORT_START

--- a/deployments/k3s/single-node/clawmanager.yaml
+++ b/deployments/k3s/single-node/clawmanager.yaml
@@ -1392,6 +1392,10 @@ spec:
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: TEAM_REDIS_URL
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
+            - name: CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED
+              value: "true"
+            - name: CLAWMANAGER_CONTROL_UI_ORIGIN
+              value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
             - name: CLAWMANAGER_DESKTOP_DIRECT_PROXY
               value: "true"
             # Required for the OpenCode Lite root-origin UI. The {instance_id}
@@ -1606,6 +1610,10 @@ spec:
             - name: CLAWMANAGER_RUNTIME_TYPE
               value: hermes
             - name: CLAWMANAGER_BACKEND_URL
+              value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+            - name: CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED
+              value: "true"
+            - name: CLAWMANAGER_CONTROL_UI_ORIGIN
               value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
             - name: CLAWMANAGER_RUNTIME_DEPLOYMENT_NAME
               value: hermes-runtime

--- a/deployments/k8s/cluster/clawmanager.yaml
+++ b/deployments/k8s/cluster/clawmanager.yaml
@@ -6247,6 +6247,10 @@ spec:
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: TEAM_REDIS_URL
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
+            - name: CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED
+              value: "true"
+            - name: CLAWMANAGER_CONTROL_UI_ORIGIN
+              value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
             - name: CLAWMANAGER_DESKTOP_DIRECT_PROXY
               value: "true"
             # Required for the OpenCode Lite root-origin UI. The {instance_id}
@@ -6448,6 +6452,10 @@ spec:
             - name: CLAWMANAGER_RUNTIME_TYPE
               value: hermes
             - name: CLAWMANAGER_BACKEND_URL
+              value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+            - name: CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED
+              value: "true"
+            - name: CLAWMANAGER_CONTROL_UI_ORIGIN
               value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
             - name: CLAWMANAGER_RUNTIME_DEPLOYMENT_NAME
               value: hermes-runtime

--- a/deployments/k8s/cluster/clawmanager.yaml
+++ b/deployments/k8s/cluster/clawmanager.yaml
@@ -6446,7 +6446,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+          image: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44
           imagePullPolicy: IfNotPresent
           env:
             - name: CLAWMANAGER_RUNTIME_TYPE
@@ -6457,10 +6457,14 @@ spec:
               value: "true"
             - name: CLAWMANAGER_CONTROL_UI_ORIGIN
               value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+            # Must cover the ClawManager app Pod IPs. Update this value when
+            # the cluster uses a Pod CIDR other than the common kubeadm range.
+            - name: CLAWMANAGER_TRUSTED_PROXY_CIDRS
+              value: "10.244.0.0/16"
             - name: CLAWMANAGER_RUNTIME_DEPLOYMENT_NAME
               value: hermes-runtime
             - name: CLAWMANAGER_RUNTIME_IMAGE_REF
-              value: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+              value: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44
             - name: CLAWMANAGER_AGENT_PORT
               value: "19090"
             - name: CLAWMANAGER_GATEWAY_PORT_START

--- a/deployments/k8s/single-node/clawmanager.yaml
+++ b/deployments/k8s/single-node/clawmanager.yaml
@@ -1606,7 +1606,7 @@ spec:
     spec:
       containers:
         - name: runtime
-          image: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+          image: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44
           imagePullPolicy: IfNotPresent
           env:
             - name: CLAWMANAGER_RUNTIME_TYPE
@@ -1617,10 +1617,14 @@ spec:
               value: "true"
             - name: CLAWMANAGER_CONTROL_UI_ORIGIN
               value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+            # Must cover the ClawManager app Pod IPs. Update this value when
+            # the cluster uses a Pod CIDR other than the common kubeadm range.
+            - name: CLAWMANAGER_TRUSTED_PROXY_CIDRS
+              value: "10.244.0.0/16"
             - name: CLAWMANAGER_RUNTIME_DEPLOYMENT_NAME
               value: hermes-runtime
             - name: CLAWMANAGER_RUNTIME_IMAGE_REF
-              value: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite:latest
+              value: ghcr.io/yuan-lab-llm/agentsruntime/hermes-lite@sha256:4fd519962d0afe796b36dade6f8e66379e7030a2c6f3c62b4a6574352b2eac44
             - name: CLAWMANAGER_AGENT_PORT
               value: "19090"
             - name: CLAWMANAGER_GATEWAY_PORT_START

--- a/deployments/k8s/single-node/clawmanager.yaml
+++ b/deployments/k8s/single-node/clawmanager.yaml
@@ -1394,6 +1394,10 @@ spec:
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
             - name: TEAM_REDIS_URL
               value: "redis://clawmanager-redis.clawmanager-system.svc.cluster.local:6379/0"
+            - name: CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED
+              value: "true"
+            - name: CLAWMANAGER_CONTROL_UI_ORIGIN
+              value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
             - name: CLAWMANAGER_DESKTOP_DIRECT_PROXY
               value: "true"
             # Required for the OpenCode Lite root-origin UI. The {instance_id}
@@ -1608,6 +1612,10 @@ spec:
             - name: CLAWMANAGER_RUNTIME_TYPE
               value: hermes
             - name: CLAWMANAGER_BACKEND_URL
+              value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
+            - name: CLAWMANAGER_HERMES_DESKTOP_WEB_ENABLED
+              value: "true"
+            - name: CLAWMANAGER_CONTROL_UI_ORIGIN
               value: "http://clawmanager-gateway.clawmanager-system.svc.cluster.local:9001"
             - name: CLAWMANAGER_RUNTIME_DEPLOYMENT_NAME
               value: hermes-runtime


### PR DESCRIPTION
Explicitly enables managed Hermes Desktop Web and configures the internal Control UI origin in all standard K3s/Kubernetes manifests. The Hermes runtime deployment now carries the same contract inputs as the control plane, allowing gateway creation to resolve trusted proxy endpoints. Adds a parsed-manifest regression test for both deployments.